### PR TITLE
Fixes for Zone::search and Zone::search_like.

### DIFF
--- a/lib/Netdot/Model.pm
+++ b/lib/Netdot/Model.pm
@@ -414,16 +414,20 @@ sub insert {
 
 =cut
 sub search_like {
-    my ($class, %argv) = @_;
+    my ($class, @args) = @_;
     $class->isa_class_method('search_like');
-    
+
+    @args = %{ $args[0] } if ref $args[0] eq "HASH";
+    my $opts = @args % 2 ? pop @args : {};
+    my %argv = @args;
+
     foreach my $key ( keys %argv ){
 	# Don't do it for foreign key fields
 	unless ( $class->meta_data->get_column($key)->links_to() ){
 	    $argv{$key} = $class->_convert_search_keyword($argv{$key});
 	}
     }
-    return $class->SUPER::search_like(%argv);
+    return $class->SUPER::search_like(%argv, $opts);
 }
 
 ############################################################################

--- a/t/Zone.t
+++ b/t/Zone.t
@@ -7,11 +7,19 @@ BEGIN { use_ok('Netdot::Model::Zone'); }
 my $obj = Zone->insert({name=>'domain.name'});
 isa_ok($obj, 'Netdot::Model::Zone', 'insert');
 
-is(Zone->search(name=>'sub.domain.name')->first, $obj, 'search' );
+is(Zone->search(name=>'sub.domain.name')->first, $obj, 'search scalar' );
+is_deeply([Zone->search(name=>'sub.domain.name')], [$obj], 'search array' );
+is(Zone->search(name=>'fake')->first, undef, 'search empty scalar' );
+is_deeply([Zone->search(name=>'fake')], [], 'search empty array' );
+
+is(Zone->search_like(name=>'domain.name')->first, $obj, 'search_like scalar' );
+is_deeply([Zone->search_like(name=>'domain.name')], [$obj], 'search_like array' );
+is(Zone->search_like(name=>'fake')->first, undef, 'search_like empty scalar' );
+is_deeply([Zone->search_like(name=>'fake')], [], 'search_like empty array' );
 
 my $serial = $obj->serial;
-$obj->update();
-is($obj->serial, $serial+1, 'update');
+$obj->update_serial();
+is($obj->serial, $serial+1, 'update_serial');
 
 $obj->delete;
 isa_ok($obj, 'Class::DBI::Object::Has::Been::Deleted', 'delete');


### PR DESCRIPTION
This patch does the following:
- adds support for options to search_like
- avoids calling the SUPER method twice
- respects wantarray in all the cases, returning either a list of objects or a Class::DBI::Iterator (not a Zone object)
