### PR TITLE
Zone import from file fails due to incorrect IP format

### DIFF
--- a/lib/Netdot/Model/Zone.pm
+++ b/lib/Netdot/Model/Zone.pm
@@ -907,7 +907,7 @@ sub is_dot_arpa {
 #    IP or block address in CIDR format
 #  Examples:
 #    my $cidr = Zone->_dot_arpa_to_ip("4.3.2.1.in-addr.arpa");
-#    $cidr == 1.2.3.4/32
+#    $cidr == 1.2.3.4
 #
 
 sub _dot_arpa_to_ip {
@@ -949,7 +949,7 @@ sub _dot_arpa_to_ip {
 	}
     }
     if ( Ipblock->validate($ipaddr, $plen) ){
-	return ("$ipaddr/$plen");
+	return ("$ipaddr");
     }else{
 	$class->throw_user(sprintf("Invalid IP address: %s/%d", $ipaddr, $plen));
     }


### PR DESCRIPTION
I am new to the project and when I tried to import my zone file I got errors and tracked them to an incorrect format. I'm not sure if this is the right way to fix the problem or if you want to change the call to Ipblock->insert to include the netmask separately. 
