### PR TITLE
fix for postgres issues

### DIFF
--- a/etc/default_data
+++ b/etc/default_data
@@ -306,12 +306,12 @@ INSERT INTO person (lastname, firstname, username, user_type, password) VALUES (
 INSERT INTO person (lastname, firstname, username, user_type, password) VALUES ('Operator', 'Operator', 'operator', '2', 'BuVbYzSB97sHKVfqvPEQyXLoZpHDz+2r4IgCS//kLyM');
 INSERT INTO person (lastname, firstname, username, user_type, password) VALUES ('Guest', 'Guest', 'guest', '3', 'hJg8YPfarcHLhphiH4AsDZ+aPDwpXIEHSPsEgRXBhuw');
 
-INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description) VALUES ('3232235520', '16', '4', '1', '1', '1', 'RFC-1918');
-INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description) VALUES ('2886729728', '12', '4', '1', '1', '1', 'RFC-1918');
-INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description) VALUES ('167772160', '8', '4', '1', '1', '1', 'RFC-1918');
-INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description) VALUES ('2851995648', '16', '4', '1', '1', '1', 'IPv4 Link Local');
-INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description) VALUES ('42540766411282592856903984951653826560', '32', '6', '1', '1', '1', 'RFC-3849');
-INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description) VALUES ('338288524927261089654018896841347694592', '10', '6', '1', '1', '1', 'Link-Local Unicast');
+INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description, use_network_broadcast) VALUES ('3232235520', '16', '4', '1', '1', '1', 'RFC-1918', false);
+INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description, use_network_broadcast) VALUES ('2886729728', '12', '4', '1', '1', '1', 'RFC-1918', false);
+INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description, use_network_broadcast) VALUES ('167772160', '8', '4', '1', '1', '1', 'RFC-1918', false);
+INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description, use_network_broadcast) VALUES ('2851995648', '16', '4', '1', '1', '1', 'IPv4 Link Local', false);
+INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description, use_network_broadcast) VALUES ('42540766411282592856903984951653826560', '32', '6', '1', '1', '1', 'RFC-3849', false);
+INSERT INTO ipblock (address, prefix, version, status, owner, used_by, description, use_network_broadcast) VALUES ('338288524927261089654018896841347694592', '10', '6', '1', '1', '1', 'Link-Local Unicast', false);
 
 
 INSERT INTO zone (name, active, default_ttl, info, minimum, mname, refresh, retry, rname, serial, expire, export_file) VALUES ('defaultdomain', '0', '86400', 'Default Zone', '86400', 'localhost.defaultdomain', '7200', '900', 'hostmaster.defaultdomain', '0', 1577858400, '/tmp/zone_export.txt');

--- a/lib/DBUTIL.pm
+++ b/lib/DBUTIL.pm
@@ -358,7 +358,7 @@ sub create_db {
         my $dbh = DBI->connect("dbi:Pg:dbname=postgres;host=$CONFIG{DB_HOST};port=$CONFIG{DB_PORT}", 
             $CONFIG{DB_DBA}, $CONFIG{DB_DBA_PASSWORD})
                 or die $DBI::errstr;
-        $dbh->do("CREATE DATABASE $CONFIG{DB_DATABASE} WITH ENCODING = 'UTF8';")
+        $dbh->do("CREATE DATABASE $CONFIG{DB_DATABASE} WITH ENCODING = 'UTF8' TEMPLATE template0;")
             or die $DBI::errstr;
     }
 }


### PR DESCRIPTION
This should fix the following errors with installdb if using postgres.

DBD::Pg::db do failed: ERROR:  new encoding (UTF8) is incompatible with the encoding of the template database (SQL_ASCII)
HINT:  Use the same encoding as in the template database, or use template0 as template. at ../lib/DBUTIL.pm line 361.

and

DBD::Pg::db do failed: ERROR:  null value in column "use_network_broadcast" violates not-null constraint at ../lib/DBUTIL.pm line 589, <DEFAULT> line 320.
