### PR TITLE
Fix for postgres template error.

### DIFF
--- a/lib/DBUTIL.pm
+++ b/lib/DBUTIL.pm
@@ -358,7 +358,7 @@ sub create_db {
         my $dbh = DBI->connect("dbi:Pg:dbname=postgres;host=$CONFIG{DB_HOST};port=$CONFIG{DB_PORT}", 
             $CONFIG{DB_DBA}, $CONFIG{DB_DBA_PASSWORD})
                 or die $DBI::errstr;
-        $dbh->do("CREATE DATABASE $CONFIG{DB_DATABASE} WITH ENCODING = 'UTF8';")
+        $dbh->do("CREATE DATABASE $CONFIG{DB_DATABASE} WITH ENCODING = 'UTF8' TEMPLATE template0;")
             or die $DBI::errstr;
     }
 }


### PR DESCRIPTION
This should fix the following error with installdb if using postgres.

DBD::Pg::db do failed: ERROR: new encoding (UTF8) is incompatible with the encoding of the template database (SQL_ASCII)
HINT: Use the same encoding as in the template database, or use template0 as template. at ../lib/DBUTIL.pm line 361.
