### PR TITLE
changed the order of update/insert for postgres

### DIFF
--- a/lib/Netdot/Model/Ipblock.pm
+++ b/lib/Netdot/Model/Ipblock.pm
@@ -1090,19 +1090,16 @@ sub fast_update{
 	    my $attrs = $ips->{$address};
 	    # Convert address to decimal format
 	    my $dec_addr = $class->ip2int($address);
-	    
-	    eval {
-		$sth2->execute($dec_addr, $attrs->{prefix}, $attrs->{version},
+	   
+	    my $rows = $sth1->execute($attrs->{timestamp}, $dec_addr);
+	    if ($rows == 0){
+	        eval {
+	    	    $sth2->execute($dec_addr, $attrs->{prefix}, $attrs->{version},
 			       $attrs->{status}, $attrs->{timestamp}, $attrs->{timestamp},
 		    );
-	    };
-	    if ( my $e = $@ ){
-		# Probably duplicate. Try to update.
-		eval {
-		    $sth1->execute($attrs->{timestamp}, $dec_addr);
 		};
-		if ( my $e2 = $@ ){
-		    $logger->error($e2);
+		if ( my $e = $@ ){
+		    $logger->error($e);
 		}
 	    }
 	}


### PR DESCRIPTION
With the normal order, updatedevices can end up filling the postgres logs with thousands of lines like this:

```
2014-01-09 22:20:14 EST ERROR:  duplicate key value violates unique constraint "ipblock1"
2014-01-09 22:20:14 EST DETAIL:  Key (address, prefix)=(184398081, 32) already exists.
2014-01-09 22:20:14 EST STATEMENT:  INSERT INTO ipblock
                                              (address,prefix,version,status,first_seen,last_seen)
                                               VALUES ($1, $2, $3, $4, $5, $6)
```

This fixes it so UPDATE is tried first, then INSERT if no rows were updated.
