### PR TITLE
Make Management>SNMP Community editable

### DIFF
--- a/htdocs/management/device.html
+++ b/htdocs/management/device.html
@@ -581,7 +581,7 @@ if ( $o->snmp_managed ){
 	    defaults=>['', \@auth_protocols, '', \@priv_protocols, \@sec_levels, ''],
 	    );
     }else{
-	$ui->add_to_fields(o=>$o, edit=>0, fields=>['community'], field_headers=>\@field_headers, 
+	$ui->add_to_fields(o=>$o, edit=>$editmgmt, fields=>['community'], field_headers=>\@field_headers, 
 			   cell_data=>\@cell_data);
     }
 }


### PR DESCRIPTION
The SNMP Community field was not editable after clicking on edit.
