### PR TITLE
Postgres log change

### DIFF
--- a/lib/Netdot/Model/Device.pm
+++ b/lib/Netdot/Model/Device.pm
@@ -5849,7 +5849,7 @@ sub _update_stp_info {
 	    }
 	    # Finally, just get the priority
 	    $uargs{bridge_priority} = $info->{stp_instances}->{$instn}->{stp_priority};
-	    if ( defined $stpinst->bridge_priority && 
+	    if ( defined $stpinst->bridge_priority && defined($uargs{bridge_priority}) && 
 		 $stpinst->bridge_priority ne $uargs{bridge_priority} ){
 		$logger->warn(sprintf("%s: STP instance %s: Bridge Priority Changed: %s -> %s", 
 				      $host, $stpinst->number, $stpinst->bridge_priority, 

--- a/lib/Netdot/Model/Device/CLI/CiscoIOS.pm
+++ b/lib/Netdot/Model/Device/CLI/CiscoIOS.pm
@@ -259,10 +259,11 @@ sub _get_fwt_from_cli {
     # ------+----------------+--------+-----+----------+--------------------------
     #    128  0024.b20e.fe0f   dynamic  Yes        255   Gi9/22
     # *  703  0022.91a9.6100   dynamic  Yes          5   Fa2/13
+    # *   10  0022.91a9.6100   dynamic  Yes   Gi3/9                             (c6500 sup2)
 
     foreach my $line ( @output ) {
 	chomp($line);
-	if ( $line =~ /^.*($CISCO_MAC)\s+dynamic\s+\S+\s+\S+\s+(\S+)\s*$/o ) {
+	if ( $line =~ /^.*($CISCO_MAC)\s+dynamic\s+\S+\s+\d+?\s+(\S+)\s*$/o ) {
 	    $mac   = $1;
 	    $iname = $2;
 	}else{

--- a/lib/Netdot/Model/DhcpScope.pm
+++ b/lib/Netdot/Model/DhcpScope.pm
@@ -661,17 +661,17 @@ sub _validate_args {
 	if ( $type eq 'global' ){
 	    $self->throw_user("$name: a global scope cannot exist within another scope");
 	}
-	if ( $type eq 'host' && !($ctype eq 'global' || $ctype eq 'group') ){
-	    $self->throw_user("$name: a host scope can only exist within a global or group scope");
+	if ( $type eq 'host' && !($ctype eq 'global' || $ctype eq 'group' || $ctype eq 'subnet' || $ctype eq 'shared-network') ){
+	    $self->throw_user("$name: a host scope can only exist within a global, group, subnet or shared-network scope");
 	}
 	if ( $type eq 'group' && $ctype ne 'global' ){
 	    $self->throw_user("$name: a group scope can only exist within a global scope");
 	}
-	if ( $type eq 'subnet' && !($ctype eq 'global' || $ctype eq 'shared-network') ){
-	    $self->throw_user("$name: a subnet scope can only exist within a global or shared-network scope");
+	if ( $type eq 'subnet' && !($ctype eq 'global' || $ctype eq 'shared-network' || $ctype eq 'group') ){
+	    $self->throw_user("$name: a subnet scope can only exist within a global, shared-network or group scope");
 	}
-	if ( $type eq 'shared-network' && $ctype ne 'global' ){
-	    $self->throw_user("$name: a shared-network scope can only exist within a global scope");
+	if ( $type eq 'shared-network' && !($ctype eq 'global' || $ctype eq 'group') ){
+	    $self->throw_user("$name: a shared-network scope can only exist within a global or group scope");
 	}
 	if ( $type eq 'pool' && !($ctype eq 'subnet' || $ctype eq 'shared-network') ){
 	    $self->throw_user("$name: a pool scope can only exist within a subnet or shared-network scope");

--- a/lib/Netdot/Model/Ipblock.pm
+++ b/lib/Netdot/Model/Ipblock.pm
@@ -1090,19 +1090,16 @@ sub fast_update{
 	    my $attrs = $ips->{$address};
 	    # Convert address to decimal format
 	    my $dec_addr = $class->ip2int($address);
-	    
-	    eval {
-		$sth2->execute($dec_addr, $attrs->{prefix}, $attrs->{version},
+	   
+	    my $rows = $sth1->execute($attrs->{timestamp}, $dec_addr);
+	    if ($rows == 0){
+	        eval {
+	    	    $sth2->execute($dec_addr, $attrs->{prefix}, $attrs->{version},
 			       $attrs->{status}, $attrs->{timestamp}, $attrs->{timestamp},
 		    );
-	    };
-	    if ( my $e = $@ ){
-		# Probably duplicate. Try to update.
-		eval {
-		    $sth1->execute($attrs->{timestamp}, $dec_addr);
 		};
-		if ( my $e2 = $@ ){
-		    $logger->error($e2);
+		if ( my $e = $@ ){
+		    $logger->error($e);
 		}
 	    }
 	}

--- a/lib/Netdot/Model/Ipblock.pm
+++ b/lib/Netdot/Model/Ipblock.pm
@@ -2916,7 +2916,7 @@ sub get_addresses_by {
     WHERE     ipblock.parent=$id
       AND     ipblock.status=ipblockstatus.id ";
     if ( ($self->version == 6) && ($self->config->get('IPV6_HIDE_DISCOVERED')) ) {
-       $query.=" AND     ipblockstatus.name != \"Discovered\" ";
+       $query.=" AND     ipblockstatus.name != \'Discovered\' ";
     }
     $query .= "GROUP BY ipblock.id 
     ORDER BY  $sort2field{$sort}";


### PR DESCRIPTION
Sorry for multiple patches in this request.  The most important patch is to change the order of INSERT/UPDATE for postgres to UPDATE/INSERT.  This stops netdot from filling up postgres logs with duplicate errors.

The other patches are to correct warning/errors when non-standard cisco gear is found.

In the future I'll break out each patch request into it's own branch so they don't come in a bunch like this.  I honestly just forgot about this from long ago and ended up rebasing/merging so I could contribute my old patches.