### PR TITLE
Apache 2.4 compatibility

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -4,7 +4,7 @@ include $(SRCROOT)/etc/utility-Makefile
 # makefile for etc/
 
 
-FILES = Default.conf netdot_apache2_radius.conf netdot_apache2_ldap.conf netdot_apache2_local.conf netdot.meta
+FILES = Default.conf netdot_apache2_radius.conf netdot_apache2_ldap.conf netdot_apache2_local.conf netdot_apache24_local.conf netdot.meta
 
 all: 
 	$(substitute)

--- a/etc/netdot_apache24_local.conf
+++ b/etc/netdot_apache24_local.conf
@@ -1,0 +1,154 @@
+# NOTE: THIS CONFIGURATION IS FOR APACHE 2.4 ONLY
+# (with Debian/Ubuntu version of Apache2::AuthCookie)
+#
+# Modify this to your liking and include it in httpd.conf.
+# -----------------------------------------------------------------------------
+
+PerlModule ModPerl::Util
+PerlModule Apache2::Request
+PerlModule Apache2::RequestRec
+PerlModule Apache2::RequestIO
+PerlModule Apache2::RequestUtil
+PerlModule Apache2::ServerUtil
+PerlModule Apache2::Connection
+PerlModule Apache2::Log
+PerlModule Apache::Session
+PerlModule APR::Table
+PerlModule ModPerl::Registry
+PerlModule "Apache2::Const => ':common'"
+PerlModule "APR::Const => ':common'"
+
+PerlModule Apache2::SiteControl
+PerlModule HTML::Mason::ApacheHandler
+
+# Uncomment this next line if you get errors from libapreq2
+# about an 'undefined symbol'
+#LoadModule apreq_module /usr/lib/apache2/modules/mod_apreq2.so
+
+# Add Netdot's libraries to @INC
+PerlSwitches -I<<Make:PREFIX>>/lib
+
+<Perl>
+# Set up the Mason handler and global variables and import modules.
+use Netdot::Mason;
+
+# Override SiteControl's login method 
+use Netdot::SiteControlLoginWrapper;
+</Perl>
+
+
+# If you would like to put netdot somewhere other than ``/netdot''
+# just change this alias, the location of the login target
+# (i.e. /netdot/NetdotLogin), and the variable NetdotPath below.  
+Alias /netdot "<<Make:PREFIX>>/htdocs/"
+
+# Force UTF8
+PerlSetVar MasonPreamble "use utf8;"
+AddDefaultCharset utf-8 
+
+# Set the path that will be protected.
+#
+# *NOTE* This variable is used to determine absolute paths where
+# needed in the netdot pages.  The Netdot corresponds to AuthName
+# Netdot below.  If you want to change the AuthName you will still
+# need this variable as the Mason code assumes you didn't change the
+# AuthName.
+PerlSetVar NetdotPath "/netdot/"
+
+# Indicate the path to the login page. Be careful, HTML::Mason can 
+# interfere with proper handling...make sure you know your dependencies.
+# See samples and Apache::AuthCookie for more information.
+PerlSetVar NetdotLoginScript /netdot/login.html
+
+# See Apache::AuthCookie for descriptions of these.  
+#
+# A general note about these Netdot variables: Some are accessed when
+# a user requests a page and others are accessed when a user attempts
+# to login.  In our setup the login target (NetdotLogin) is in the
+# same apache scope as the netdot pages (/netdot) and these variables
+# are specified at the global scope so there isn't an issue, but if
+# you decide to move them inside a Directory, Files, or Location block
+# and move the login target be sure that you put the right variables
+# in the right places (hint: you will probably have to read the
+# AuthCookie code as it is not clear from the docs, if you don't want
+# any duplicates).  The same probably goes for the SiteControl and
+# other non prefixed variables, but since they don't have prefixes it
+# would be inconsiderate to put them at the top level (pollute the
+# global name space), and so if you move the login target be sure to
+# duplicate any relevant variables (again, it might not be obvious
+# which).
+
+# If this is set you wont be able to use unqualified hostnames and
+# rely on DNS to supply the domain.  DNS will supply the domain no
+# doubt, but the browser doesn't see it so the cookie will be invalid.
+# Also, a hostname isn't valid here.
+#PerlSetVar NetdotDomain .uoregon.edu
+PerlSetVar NetdotCache 1
+
+# We change the value of NetdotExpires dynamically to implement both
+# temporary and permanent sessions.  NetdotTemporySessionExpires
+# specifies the length of the tempory sessions, i.e. it corresponds to
+# NetdotExpires in a typical AuthCookie setup.
+PerlSetVar NetdotTemporarySessionExpires +2h
+
+# Apache 2.4 Authorization
+PerlAddAuthzProvider user Apache2::SiteControl->authz_handler
+
+<Directory <<Make:PREFIX>>/htdocs/>
+   # Other applications may have attempted to override how .html files are
+   # interpreted.  We need to reset this so that HTML::Mason can work 
+   # correctly.
+   AddType text/html .html
+
+   # Defaults: everything is protected and handled by mason
+   SetHandler perl-script
+   PerlHandler Netdot::Mason
+   AuthType Apache2::SiteControl
+   AuthName Netdot
+   Require valid-user
+
+   # Prevent mason from handling css and javascript
+   <FilesMatch (\.css|\.js)$>
+       SetHandler default-handler
+   </FilesMatch>
+
+   # Allow access to the css and and title image so the login page
+   # displays correctly.
+   <FilesMatch (\.css|title\.png)$>
+       Require all granted
+   </FilesMatch>
+
+   <Files login.html>
+       Require all granted
+   </Files>
+
+   <Files NetdotLogin>
+       Require all granted
+       PerlHandler Netdot::SiteControlLoginWrapper->login
+   </Files>
+
+   # Use Local authentication
+   PerlSetVar SiteControlMethod Netdot::AuthLocal
+
+   # Turn on debugging
+   PerlSetVar AccessControllerDebug 1
+   PerlSetVar AuthCookieDebug 1
+   PerlSetVar SiteControlDebug 1
+
+   # Configure the factories. See SiteControl::UserFactory and
+   # SiteControl::ManagerFactory
+   PerlSetVar SiteControlManagerFactory Netdot::NetdotPermissionFactory
+
+   # Configure the location of the session data on server disks
+   # NOTE: apache should have read/write access to these locations. 
+   PerlSetVar SiteControlSessions <<Make:PREFIX>>/tmp/sessions
+   PerlSetVar SiteControlLocks <<Make:PREFIX>>/tmp/sessions/locks
+
+   # Tell mod_perl that you want this module to control access:
+   PerlAuthenHandler Apache2::SiteControl->authenticate
+
+   # See Apache2::SiteControl::UserFactory.  There are more variables,
+   # but this seems to be the only one which makess SiteControl insult
+   # you in the logs :P
+   PerlSetVar UserObjectPasswordKey "Netdot gets the last laugh"
+</Directory>


### PR DESCRIPTION
Add netdot_apache24_local.conf which works with Apache 2.4 in Ubuntu 14.04
(note: this requires a version of Apache2::AuthCookie based on the
unreleased httpd24 branch, but Debian have done this)

Fixes redmine #1808
