### PR TITLE
only update DNS record when name is different

### DIFF
--- a/lib/Netdot/Model/Ipblock.pm
+++ b/lib/Netdot/Model/Ipblock.pm
@@ -2235,9 +2235,12 @@ sub update_a_records {
 						       $host, $self->address, $name) );
 			    }else{
 				# Just update the current name, then
-				$rr->update(\%rrstate);
-				$logger->debug(sub{ sprintf("%s: Updated DNS record for %s: %s", 
-							    $host, $self->address, $name) });
+				# Only update if name is different
+				if ($rr->name ne $rrstate{"name"}) {
+				    $rr->update(\%rrstate);
+				    $logger->debug(sub{ sprintf("%s: Updated DNS record for %s: %s", 
+					    		    $host, $self->address, $name) });
+			    }
 			    }
 			}
 		    }


### PR DESCRIPTION
Don't update the record when the name is the same, otherwise the zone and the serial will be unnecessary modified.
