### PR TITLE
View template for Table DhcpScope added

### DIFF
--- a/etc/netdot.meta
+++ b/etc/netdot.meta
@@ -3340,6 +3340,11 @@ $meta = {
         'physaddr',
         'text'
       ],
+      template => [
+        'name',
+        'type',
+        'active'
+      ],
       pool => [
         'name',
         'type',


### PR DESCRIPTION
Without the view no header data is displayed when showing a DHCP template. That confuses my users.