### PR TITLE
pass a more descriptive error message for PhysAddr validation

### DIFF
--- a/lib/Netdot/Model/DhcpScope.pm
+++ b/lib/Netdot/Model/DhcpScope.pm
@@ -462,8 +462,9 @@ sub _objectify_args {
 
     if ( $argv->{physaddr} && !ref($argv->{physaddr}) ){
 	# Could be an ID or an actual address
-	my $phys;
-	if ( PhysAddr->validate($argv->{physaddr}) ){
+    my $phys;
+    my $validation_error_message = undef;
+    if ( PhysAddr->validate($argv->{physaddr}, \$validation_error_message) ){
 	    # It looks like an address
 	    $phys = PhysAddr->find_or_create({address=>$argv->{physaddr}});
 	}elsif ( $argv->{physaddr} !~ /\D/ ){
@@ -473,7 +474,11 @@ sub _objectify_args {
 	if ( $phys ){
 	    $argv->{physaddr} = $phys;
 	}else{
-	    $self->throw_user("Could not find or create physaddr");
+        my $error_message = "Could not find or create physaddr";
+        if (defined($validation_error_message)) {
+            $error_message .= "\n$validation_error_message";
+        }
+        $self->throw_user($error_message);
 	}
     }
 


### PR DESCRIPTION
When a routine calls PhysAddr->validate to validate an L2 address the
descriptive message is lost by just returning a boolean success or
failure. Instead allow passing in a reference to a scalar to give the
calling function an opportunity to give the user more information about
the specifics behind Netdot rejecting the MAC address they entered.

Small amounts of whitespace formatting were performed in this commit as
well as the functional changes. Changes such as removing trailing
whitespace in functions that were touched and also replacing tabs with
four spaces.