### PR TITLE
allow exporting process to run arbitrary hooks

### DIFF
--- a/etc/Default.conf
+++ b/etc/Default.conf
@@ -948,6 +948,9 @@ RANCID_TYPE_MAP => {
     'netscreen'  => 'netscreen',
 },
 
+# Directory that contains export modules and their corresponding hooks
+EXPORTER_HOOKS_DIR => '<<Make:PREFIX>>/etc/exporter/hooks',
+
 #####################################################################
 #  - BIND - www.isc.org
 #

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -3,10 +3,11 @@ include $(SRCROOT)/etc/utility-Makefile
 #
 # makefile for etc/
 
-
+NDIR = exporter exporter/hooks
 FILES = Default.conf netdot_apache2_radius.conf netdot_apache2_ldap.conf netdot_apache2_local.conf netdot_apache24_local.conf netdot.meta
 
 all: 
+	$(mkdirs)
 	$(substitute)
 	if ! test -r $(PREFIX)/$(DIR)/Site.conf; then \
 	  $(SED) -r $(REPLACEMENT_EXPRESSIONS) Site.conf \

--- a/htdocs/export/config_tasks.html
+++ b/htdocs/export/config_tasks.html
@@ -112,6 +112,7 @@ my $manager = $ui->get_permission_manager($r);
 
 <%perl>
 if ( $submit ){
+    my $person = $ui->get_user_person($user);
     unless ( $manager && $manager->can($user, 'access_admin_section', 'Export:Submit_Configuration') ){
 	$m->comp('/generic/error.mhtml', error=>"You don't  have permission to perform this operation")
     }
@@ -130,7 +131,14 @@ if ( $submit ){
     $dhcp_logger->add_appender($logstr);
 
     foreach my $type ( @config_types ){
-	my %args;
+	my %args = (
+        user => {
+            person_username  => $person->username,
+            person_firstname => $person->firstname,
+            person_lastname  => $person->lastname,
+            person_email     => $person->email,
+        },
+    );
 	if ( $type eq 'BIND' ){
 	    $args{zone_ids} = \@zones if ( scalar @zones && $zones[0] ne "" );
 	    $args{force}    = 1 if ($bind_force);


### PR DESCRIPTION
This commit allows local Netdot instances to run their own code at various
hook points in the exporting process.

This commit only adds hook points for exporting BIND configs. However, adding
hook points for other classes should be straightforward and simple due to
leveraging the 'hook' subroutine.

Pertinent data is passed to the hook programs via a JSON encoded data
structure on the command line.