### PR TITLE
update BGP sessions even if the contact list is undefined

### DIFF
--- a/lib/Netdot/Model/Device.pm
+++ b/lib/Netdot/Model/Device.pm
@@ -2743,7 +2743,9 @@ sub update_bgp_peering {
 	$pstate{last_changed} = $self->timestamp;
 
 	# Assign the first available contactlist from the device list
-	$pstate{contactlist} = $self->contacts->first->contactlist;
+	if (defined ($self->contacts->first)) {
+	    $pstate{contactlist} = $self->contacts->first->contactlist;
+        }
 
 	$p = BGPPeering->insert(\%pstate);
 	my $peer_label;


### PR DESCRIPTION
If the contact list for a device is null, then netdot will return ''Can't call method "contactlist" on an undefined value'' when an update is run on a device with BGP sessions configured.

The previous behaviour prevents bgp sessions from being created when there is no contact list defined. There's an argument to be said that this is technically the correct behaviour.
