### PR TITLE
ensure remaining nibbles get pushed onto the resulting address

### DIFF
--- a/bin/perldeps.pl
+++ b/bin/perldeps.pl
@@ -52,6 +52,7 @@ my @DEPS = (
     {cpan=>'Net::Patricia 1.20', apt=> 'libnet-patricia-perl', rpm=>''},
     {cpan=>'Authen::Radius', apt=>'libauthen-radius-perl', rpm=>'perl-Authen-Radius'},
     {cpan=>'Test::Simple' , apt=> 'libtest-simple-perl', rpm=>''},
+    {cpan=>'Test::Exception' , apt=> 'libtest-exception-perl', rpm=>''},
     {cpan=>'Net::IRR', apt=> 'libnet-irr-perl', rpm=>''},
     {cpan=>'Time::Local', apt=> 'libtime-local-perl', rpm=>''},
     {cpan=>'File::Spec',apt=> 'libfile-spec-perl', rpm=>''},

--- a/lib/Netdot/Model/Zone.pm
+++ b/lib/Netdot/Model/Zone.pm
@@ -988,10 +988,18 @@ sub _dot_arpa_to_ip {
 	my @g; my $m;
 	for (my $i=1; $i<=scalar(@n); $i++){
 	    $m .= $n[$i-1];
+        # If we are at a "group" boundary, then push it on.
 	    if ( $i % 4 == 0 ){
 		push @g, $m;
 		$m = "";
 	    }
+        # If we are at the last character of the address, then process
+        # what is left.
+        elsif ($i == @n) {
+            # Ensure we have four characters in the group before pushing.
+            $m .= '0' x (4 - length($m));
+            push @g, $m;
+        }
 	}
 	$ipaddr = join ':', @g;
 	if ( $plen < 128 ){

--- a/t/Zone.t
+++ b/t/Zone.t
@@ -1,11 +1,30 @@
 use strict;
 use Test::More qw(no_plan);
+use Test::Exception;
 use lib "lib";
 
 BEGIN { use_ok('Netdot::Model::Zone'); }
 
 my $obj = Zone->insert({name=>'domain.name'});
 isa_ok($obj, 'Netdot::Model::Zone', 'insert');
+
+lives_and { is(Zone->_dot_arpa_to_ip('1.in-addr.arpa'), '1.0.0.0/8', 'IPv4 /8 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('2.1.in-addr.arpa'), '1.2.0.0/16', 'IPv4 /16 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('3.2.1.in-addr.arpa'), '1.2.3.0/24', 'IPv4 /24 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('4.3.2.1.in-addr.arpa'), '1.2.3.4/32', 'IPv4 /32 .arpa zone to address') };
+
+lives_and { is(Zone->_dot_arpa_to_ip('1.ip6.arpa'), '1000::/4', 'IPv6 /4 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('2.1.ip6.arpa'), '1200::/8', 'IPv6 /8 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('3.2.1.ip6.arpa'), '1230::/12', 'IPv6 /12 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('4.3.2.1.ip6.arpa'), '1234::/16', 'IPv6 /16 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('5.4.3.2.1.ip6.arpa'), '1234:5000::/20', 'IPv6 /20 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('6.5.4.3.2.1.ip6.arpa'), '1234:5600::/24', 'IPv6 /24 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('7.6.5.4.3.2.1.ip6.arpa'), '1234:5670::/28', 'IPv6 /28 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('8.7.6.5.4.3.2.1.ip6.arpa'), '1234:5678::/32', 'IPv6 /32 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('9.8.7.6.5.4.3.2.1.ip6.arpa'), '1234:5678:9000::/36', 'IPv6 /36 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('a.9.8.7.6.5.4.3.2.1.ip6.arpa'), '1234:5678:9a00::/40', 'IPv6 /40 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('b.a.9.8.7.6.5.4.3.2.1.ip6.arpa'), '1234:5678:9ab0::/44', 'IPv6 /44 .arpa zone to address') };
+lives_and { is(Zone->_dot_arpa_to_ip('c.b.a.9.8.7.6.5.4.3.2.1.ip6.arpa'), '1234:5678:9abc::/48', 'IPv6 /48 .arpa zone to address') };
 
 is(Zone->search(name=>'sub.domain.name')->first, $obj, 'search scalar' );
 is_deeply([Zone->search(name=>'sub.domain.name')], [$obj], 'search array' );


### PR DESCRIPTION
If the prefix length for an ip6.arpa zone is not a multiple of 16, then
remaining nibbles will get silently dropped.