### PR TITLE
add case insensitive searching for zone names

### DIFF
--- a/lib/Netdot/Model.pm
+++ b/lib/Netdot/Model.pm
@@ -6,6 +6,7 @@ use Time::Local;
 use Net::DNS;
 use Digest::MD5 qw(md5_hex);
 use Scalar::Util qw(blessed);
+use Class::DBI::AbstractSearch;
 
 =head1 NAME
 

--- a/t/Zone.t
+++ b/t/Zone.t
@@ -5,8 +5,20 @@ use lib "lib";
 
 BEGIN { use_ok('Netdot::Model::Zone'); }
 
-my $obj = Zone->insert({name=>'domain.name'});
-isa_ok($obj, 'Netdot::Model::Zone', 'insert');
+my $obj = Zone->insert(
+    {
+        name => 'domain.name',
+    },
+);
+isa_ok($obj, 'Netdot::Model::Zone', 'insert zone');
+
+my $alias = ZoneAlias->insert(
+    {
+        name => 'alias.name',
+        zone => $obj->id,
+    },
+);
+isa_ok($alias, 'Netdot::Model::ZoneAlias', 'insert zone alias');
 
 lives_and { is(Zone->_dot_arpa_to_ip('1.in-addr.arpa'), '1.0.0.0/8', 'IPv4 /8 .arpa zone to address') };
 lives_and { is(Zone->_dot_arpa_to_ip('2.1.in-addr.arpa'), '1.2.0.0/16', 'IPv4 /16 .arpa zone to address') };
@@ -28,8 +40,15 @@ lives_and { is(Zone->_dot_arpa_to_ip('c.b.a.9.8.7.6.5.4.3.2.1.ip6.arpa'), '1234:
 
 is(Zone->search(name=>'sub.domain.name')->first, $obj, 'search scalar' );
 is_deeply([Zone->search(name=>'sub.domain.name')], [$obj], 'search array' );
+is(Zone->search(name=>'sub.DoMaIn.NaMe')->first, $obj, 'case insensitive search scalar' );
+is_deeply([Zone->search(name=>'sub.DoMaIn.NaMe')], [$obj], 'case insensitive search array' );
 is(Zone->search(name=>'fake')->first, undef, 'search empty scalar' );
 is_deeply([Zone->search(name=>'fake')], [], 'search empty array' );
+
+is(Zone->search(name=>'alias.name')->first, $obj, 'alias search scalar' );
+is_deeply([Zone->search(name=>'alias.name')], [$obj], 'alias search array' );
+is(Zone->search(name=>'AlIaS.NaMe')->first, $obj, 'case insensitive alias search scalar' );
+is_deeply([Zone->search(name=>'AlIaS.NaMe')], [$obj], 'case insensitive alias search array' );
 
 is(Zone->search_like(name=>'domain.name')->first, $obj, 'search_like scalar' );
 is_deeply([Zone->search_like(name=>'domain.name')], [$obj], 'search_like array' );


### PR DESCRIPTION
Domain names are case insensitive. Searches for a mixed case zone and a
lowercase zone with the same symbols (letters) should return the same
zone object.

This point will be particularly evident when searching for IPv6 arpa
domains (zones) created before commit 9f650144017d when the default for
NetAddr::IP would create v6 addresses in upper case - thus an uppercase
ip6.arpa zone. Post commit 9f650144017d lowercase zones would be
searched for - thus a search miss would occur.

Additionally this commit adds tests for case insensitive zone searches,
as well as alias searches.

Lastly, whitespace was modified for the Zone::search subroutine to
elimitate trailing spaces and translate tabs to 4 spaces.