### PR TITLE
center ip address link in ipblock subnet view

### DIFF
--- a/htdocs/css/style.css
+++ b/htdocs/css/style.css
@@ -471,7 +471,13 @@ div.clear { clear: both }
     margin: 0px;
   }
 
-
+/*
+ * Prefer addresses to be centered in the ipblock view of a subnet.
+ */
+table > * > tr > td.datatabler1_ipb div,
+table > * > tr > td.datatabler2_ipb div {
+    text-align: center;
+}
 
     .ipaddr_disabled { background-color: #cccccc; }
     .ipaddr_disabled_2 { background-color: #dddddd; }

--- a/htdocs/management/subnet.mhtml
+++ b/htdocs/management/subnet.mhtml
@@ -28,6 +28,9 @@ my $make_cell = sub {
 
     our $DISCOVERED_OVERWRITE;
 
+    # Wrap the displayed address in a div before wrapping it in an anchor tag
+    # so that the whole cell is clickable.
+    $disp_addr = '<div class="'.$divclass.'" title="'.$divtitle.'" width="100%">'.$disp_addr.'</div>';
     my $str = $disp_addr;
     if ( $caller eq 'choose_ip.html' ){
 	# Called as a popup window
@@ -75,7 +78,6 @@ my $make_cell = sub {
 	    }
 	}
     }
-    $str = '<div class="'.$divclass.'" title="'.$divtitle.'" width="100%">'.$str.'</div>';
     return $str;
 };
 </%once>


### PR DESCRIPTION
When viewing a subnet via the ipblock view, it would be helpful to center the
text of the address in the table cell. Also, it would be great to make the
whole cell clickable instead of just the text. This will help those of
us who use tiny fonts to more easily click the ipblock/address.