### PR TITLE
1.0.8/render block container as block for any non addresses

### DIFF
--- a/htdocs/management/ipblock_list.mhtml
+++ b/htdocs/management/ipblock_list.mhtml
@@ -33,7 +33,7 @@ my $i;
 
 my (@headers, @rows);
 if ( $type ){
-    unless ( $type =~ /^address|block$/ ){
+    unless ( $type =~ /^(?:address|block)$/ ){
 	$m->comp('error.mhtml', error => "Unknown type: $type");
     }
 }else{

--- a/htdocs/management/ipblock_list.mhtml
+++ b/htdocs/management/ipblock_list.mhtml
@@ -37,10 +37,12 @@ if ( $type ){
 	$m->comp('error.mhtml', error => "Unknown type: $type");
     }
 }else{
-    if ( ($objects->[0])->is_address ){ # We're dealing with addresses
-	$type = "address";
-    }else{
-	$type = "block";
+    $type = 'address';
+    for my $object (@$objects) {
+        if (! $object->is_address) {
+            $type = 'block';
+            last;
+        }
     }
 }
 </%init>


### PR DESCRIPTION
When a container has a mix of addresses (hosts) and other subnets or containers it should display the block view if any of its descendants are non-addresses.