### PR TITLE
allow Netdot to start with a selected domain for new A/AAAA records

### DIFF
--- a/etc/Default.conf
+++ b/etc/Default.conf
@@ -740,6 +740,13 @@ DEFAULT_HINFO_OS_VALUES => {
     'LINUX'   => 'Linux', 
 },
 
+# When creating a new DNS A/AAAA record, the list of available domains (zones)
+# are populated in a dropdown. The "closest" possible forward zone is
+# determined and placed at the top of the list of zones. This option instructs
+# Netdot to automatically select that domain for creating the A/AAAA record.
+# NOTE: the user may still select a different domain. This option only
+# specifies whether a domain should be selected by default in the dropdown.
+SELECT_DEFAULT_DOMAIN_FOR_NEW_ADDRESS_RECORD => 0,
 
 # Netdot tries to automate the assignment of DNS names for each
 # IP address associated with a Device Interface.  We chose to 

--- a/htdocs/management/ip.html
+++ b/htdocs/management/ip.html
@@ -815,8 +815,10 @@ if (!$edit){
             Name: <input type="text" name="new_a_name" value="">
 	    <select name="new_a_zone">
             <option value=""> - select - </option>
+%          my $i = 0;
 %	    foreach my $zone ( @zone_list ){
-                <option value="<% $zone->id %>"><% $zone->get_label %></option>
+                <option value="<% $zone->id %>"<% ($i == 0 && Netdot->config->get("SELECT_DEFAULT_DOMAIN_FOR_NEW_ADDRESS_RECORD")) ? ' selected' : '' %>><% $zone->get_label %></option>
+%               $i++;
 %	    }
             </select>
             <p><input type="button" name="cancel_button" value="cancel" onClick="history.go(-1);">


### PR DESCRIPTION
Add a config directive to allow the dropdown for creating a new A/AAAA record to start with a domain already selected.