### PR TITLE
Fixes for #1906

### DIFF
--- a/htdocs/css/style.css
+++ b/htdocs/css/style.css
@@ -431,7 +431,10 @@ div.clear { clear: both }
     padding: 4px;
 }
 
-
+table.ip_block_subnet_view {
+    width: 100%;
+    table-layout: fixed;
+}
 
   .formtablec1	    { background-color: #ffffee; text-align: right}
   .formtablec2	    { background-color: #f0f7e9; text-align: left; vertical-align: bottom; }

--- a/htdocs/generic/data_table.mhtml
+++ b/htdocs/generic/data_table.mhtml
@@ -21,17 +21,27 @@ Arguments:
 </%doc>
 
 <%args>
-@field_headers => undef;
-@data          => ();
-$subclass      => "";
-@style         => ();
-@rowstyle      => ();
+@field_headers => undef
+@data          => ()
+$subclass      => ""
+@style         => ()
+@rowstyle      => ()
+@table_classes => ()
 </%args>
+
+<%init>
+my $table_classes = undef;
+if (@table_classes > 0) {
+    # build the classes attribute for the table element...
+    $table_classes = join ' ', @table_classes;
+    $table_classes = qq{class="$table_classes"};
+}
+</%init>
 
 % if( $subclass ) { $subclass = '_'.$subclass; }
 
 
-<table border="0" width="100%" cellspacing="0">
+<table border="0" width="100%" cellspacing="0"<% (defined $table_classes) ? " $table_classes" : '' %>>
   <tr>
 % if ( @style ){
 %     for (my $i=0; $i < scalar @field_headers; $i++) {

--- a/htdocs/management/subnet.mhtml
+++ b/htdocs/management/subnet.mhtml
@@ -221,5 +221,9 @@ for( my $i=0; $i<($num/$cols); $i++ ) {
 
 </%perl>
 
-<& /generic/data_table.mhtml, field_headers=>\@headers, data=>\@rows, subclass=>"ipb" &>
-
+<& /generic/data_table.mhtml,
+    field_headers => \@headers,
+    data          => \@rows,
+    subclass      => "ipb",
+    table_classes => ('ip_block_subnet_view'),
+&>


### PR DESCRIPTION
Using the CSS attribute/value "table-layout: fixed" for the subnet view
table gives each cell equal width.

Extend htdocs/generic/data_table.mhtml to allow passing of CSS classes
to the component for the HTML table it generates.

Remove extraneous semicolons for %args block.