### PR TITLE
factor out code to determine DNS address record label

### DIFF
--- a/htdocs/management/ip.html
+++ b/htdocs/management/ip.html
@@ -102,16 +102,15 @@ if ( $id ){
 	$BLOCK_VIEW_MAX = Netdot->config->get('CONTAINER_BLOCK_VIEW_MAX_PREFIX');
     }
     if ( $o->version == 4 ){
-        $dns_address_record_label = 'A';
 	if ( $view_format eq 'block' ){
 	    if ( $BLOCK_VIEW_MAX && ($o->prefix < $BLOCK_VIEW_MAX) ){
 		$view_format = 'list';
 	    }
 	}
     }elsif ( $o->version == 6 ){
-        $dns_address_record_label = 'AAAA';
 	$view_format = 'list' if $view_format eq 'block';
     }
+    $dns_address_record_label = $o->dns_address_record_label;
 
 }else{
     $title = "Search";
@@ -337,6 +336,7 @@ if( $_action eq "SHOW_ROOTS" && !$id && $rootversion ){
 	    $id = $block->id;
 	    if( $o->is_address ) {
 		$added_ip  = 1;
+            $dns_address_record_label = $o->dns_address_record_label;
 	    }else {
 		$added_block = 1;
 	    }

--- a/lib/Netdot/Model/Ipblock.pm
+++ b/lib/Netdot/Model/Ipblock.pm
@@ -1568,6 +1568,37 @@ sub is_address {
 
 ##################################################################
 
+=head2 dns_address_record_label - A or AAAA
+
+    DNS address records have different labels for IPv4 or IPv6. Return the
+    correct label depending on the version of this object.
+
+ Arguments:
+    None
+ Returns:
+    'A' for IPv4
+    'AAAA' for IPv6
+    undef for anything else
+
+=cut
+
+sub dns_address_record_label {
+    my $self = shift;
+    $self->isa_object_method('dns_address_record_label');
+
+    if ($self->version == 4) {
+        return 'A';
+    }
+    elsif ($self->version == 6) {
+        return 'AAAA';
+    }
+    else {
+        return undef;
+    }
+}
+
+##################################################################
+
 =head2 update - Update an Ipblock object in DB
 
     Modify given fields of an Ipblock and (optionally) all its descendants.

--- a/t/Ipblock.t
+++ b/t/Ipblock.t
@@ -37,6 +37,8 @@ is($address->status->name, 'Static', 'insert address');
 
 is($address->is_address, 1, 'is_address');
 
+is($address->dns_address_record_label, 'A', 'DNS IPv4 address record label');
+
 is($address->parent, $subnet, 'address/subnet hierarchy');
 is($subnet->parent, $container, 'subnet/container hierarchy');
 
@@ -154,6 +156,14 @@ my $v6subnet = Ipblock->insert({
     version => 6,
     status  => 'Subnet',
 });
+
+my $v6address = Ipblock->insert({
+    address => "2001:db8::beef:cafe",
+    prefix  => '128',
+    version => 6,
+    status  => 'Static',
+});
+is($v6address->dns_address_record_label, 'AAAA', 'DNS IPv6 address record label');
 
 is($v6subnet->parent, $v6container, 'v6_parent');
 


### PR DESCRIPTION
Hey Carlos,

The branch you merged earlier today to set the correct DNS address record label was slightly incomplete. When one creates a new address (either v4 or v6) the label for the DNS address record still used 'A/AAAA' when it could have been smarter and chosen the right label. This branch fixes those omissions.

Thanks!

-m


There is a second location in management/ip.html where we need to set
the label for the DNS address record. This second location in the code
get executed when a new address is created (and there is no "id" passed
in via the arguments of the Mason component.)

The need for a second place to contain logic warrants factoring out the
logic to determine the (DNS address record) label for a given IP block
object into the class.

Add new subroutine to Netdot::Model::Ipblock, dns_address_record_label
that returns 'A' or 'AAAA' depending on the version of the object.

Also add in some unit tests.