### PR TITLE
add the MAC address to the brief view of DHCP Scopes

### DIFF
--- a/etc/netdot.meta
+++ b/etc/netdot.meta
@@ -3378,6 +3378,7 @@ $meta = {
       ],
       brief => [
         'name',
+        'physaddr',
         'type',
       ]
     }


### PR DESCRIPTION
The impetus for this change is the ip.html view of an address with a
DHCP host scope. It would be nice to see the MAC address with all the
other relevant details (A records, etc.)