### PR TITLE
mark A/AAAA records as needing to be regenerated when address changes

### DIFF
--- a/lib/Netdot/Model/Ipblock.pm
+++ b/lib/Netdot/Model/Ipblock.pm
@@ -1691,6 +1691,16 @@ sub update {
 	}
     }
 
+    # Update any of the A/AAAA records if the address changed.
+    $logger->trace('Evaluating if address changed for Ipblock: '.$self->id);
+    if ($self->address ne $bak{address}) {
+        $logger->debug("Address changed from $bak{address} to ".$self->address);
+        for my $rraddr (RRADDR->search(ipblock => $self->id)) {
+            $logger->debug('Marking RRADDR DNS record ('.$rraddr->id.') as needing to be regenerated.');
+            $rraddr->_host_audit;
+        }
+    }
+
     # Generate hostaudit entry if needed
     if ( $self->parent && $self->parent->dhcp_scopes
 	 && ($bak{status}->id != $state{status}) ){


### PR DESCRIPTION
When editing an ipblock, the A/AAAA records are not being marked as
needing to be regenerated - only their PTR (.arpa) zone gets marked.

This commit fixes that issue.