### PR TITLE
Handling of "removed" interfaces

### DIFF
--- a/bin/prune_db.pl
+++ b/bin/prune_db.pl
@@ -34,6 +34,7 @@ my $usage = <<EOF;
     -R, --rr                       DNS Resource Records
     -a, --audit                    Audit records
     -t, --hostaudit                Host Audit records
+    -i, --interfaces               'Removed' interfaces
     -d, --num_days                 Number of days worth of items to keep (default: $self{NUM_DAYS});
     -r, --rotate                   Rotate forwarding tables and ARP caches (rather than delete records) 
     -p, --pretend                  Show activity without actually deleting anything
@@ -52,6 +53,7 @@ my $result = GetOptions(
     "R|rr"            => \$self{RR},
     "a|audit"         => \$self{AUDIT},
     "t|hostaudit"     => \$self{HOSTAUDIT},
+    "i|interfaces"    => \$self{INTERFACES},
     "d|num_days=i"    => \$self{NUM_DAYS},
     "r|rotate"        => \$self{ROTATE},
     "p|pretend"       => \$self{PRETEND},
@@ -70,7 +72,8 @@ if ( !$result ){
 }
 
 unless  ( $self{FWT} || $self{ARP} || $self{MACS} || 
-	  $self{IPS} || $self{RR} || $self{HOSTAUDIT} || $self{AUDIT} ){
+	  $self{IPS} || $self{RR} || $self{HOSTAUDIT} || 
+          $self{AUDIT} || $self{INTERFACES} ){
     print $usage;
     die "Error: Missing required args\n";
 }
@@ -165,6 +168,14 @@ if ( $self{AUDIT} ){
     $r = $dbh->do("DELETE FROM audit WHERE tstamp < '$sqldate'")
 	unless $self{PRETEND};
     $rows_deleted{audit} = $r;
+}
+
+if ( $self{INTERFACES} ){
+    my $r;
+    $logger->debug("Deleting all interfaces with 'removed' doc status");
+    $r = $dbh->do("DELETE FROM interface WHERE doc_status='removed'")
+	unless $self{PRETEND};
+    $rows_deleted{interfaces} = $r;
 }
 
 if ( $self{FWT} ){

--- a/lib/Netdot/Exporter.pm
+++ b/lib/Netdot/Exporter.pm
@@ -115,7 +115,8 @@ sub get_device_info {
           LEFT OUTER JOIN ipservice ON ipservice.ip=ip.id
           LEFT OUTER JOIN service ON ipservice.service=service.id
           WHERE     d.monitored='1'
-               AND  i.device=d.id                  
+               AND  i.device=d.id
+               AND  i.doc_status!='removed'
                AND  d.name=rr.id 
                AND  rr.zone=zone.id
          ";

--- a/t/Exporter.t
+++ b/t/Exporter.t
@@ -39,9 +39,18 @@ for my $name (@dev_names){
     foreach my $int ($dev->interfaces){
 	$int->update({speed=>'100'});
     }
+    # Create a "removed" interface to test that we do not
+    # get it in the exported data
+    Interface->insert({
+	device=>$dev,
+	name=>'dummy',
+	number=>'999',
+	doc_status=>'removed'});
     $i++;
 }
+
 my $info = $exporter->get_device_info();
+
 my @hdevs = map { $info->{$_} } sort keys %$info;
 is($hdevs[0]->{hostname}, "test1.defaultdomain");
 is($hdevs[0]->{site_name}, "tsite1");
@@ -50,13 +59,16 @@ is($hdevs[1]->{site_name}, "tsite2");
 is($hdevs[2]->{hostname}, "test3.defaultdomain");
 is($hdevs[2]->{site_name}, "tsite3");
 
-my $f_int = (keys %{$hdevs[0]->{interface}})[0];
+my @ints = keys %{$hdevs[0]->{interface}};
+is(length(@ints), 1);
+my $f_int = $ints[0];
 is($hdevs[0]->{interface}->{$f_int}->{speed}, 100);
 
 $info = $exporter->get_device_info(site=>'tsite1');
 my @ids = (sort keys %$info);
 is(scalar(@ids), 1);
 is($info->{$ids[0]}->{hostname}, "test1.defaultdomain");
+
 
 my $nagios = Netdot::Exporter->new(type=>'Nagios');
 isa_ok($nagios, 'Netdot::Exporter::Nagios', 'Constructor');


### PR DESCRIPTION
* There is no point in exporting interfaces marked as "removed" in exported data used for monitoring
* Allow user to delete those interfaces periodically using the prune_db script