### PR TITLE
Fix: asset_tasks.html : $mac is not defined (related to #68)

### DIFF
--- a/htdocs/management/asset_tasks.html
+++ b/htdocs/management/asset_tasks.html
@@ -164,6 +164,9 @@ if ( $submit ){
 
 		    # MAC
 		    if ( $d{physaddr} ){
+			my $mac = PhysAddr->validate($d{physaddr});
+			Netdot->throw_user("Invalid MAC: $d{physaddr}")
+			    unless $mac;
 			if ( PhysAddr->search(address=>$mac)) {
 			    $dups{macs}{$mac} = 1;
 			    next;

--- a/htdocs/management/asset_tasks.html
+++ b/htdocs/management/asset_tasks.html
@@ -164,9 +164,14 @@ if ( $submit ){
 
 		    # MAC
 		    if ( $d{physaddr} ){
-			my $mac = PhysAddr->validate($d{physaddr});
-			Netdot->throw_user("Invalid MAC: $d{physaddr}")
-			    unless $mac;
+			my $mac = $d{physaddr};
+			eval {
+			    $mac = PhysAddr->validate($mac);
+			};
+			if ( my $e = $@ ){
+			    Netdot->throw_user("Invalid MAC: $e");
+			    next;
+			}
 			if ( PhysAddr->search(address=>$mac)) {
 			    $dups{macs}{$mac} = 1;
 			    next;


### PR DESCRIPTION
After the merge of #68, $mac was no more defined in this file.
This fix reverts the removal of the 3 affected lines, and, uses the new validation format for mac addresses.