### PR TITLE
Fix OUI when using custom formatting MAC Addresses (related to #68)

### DIFF
--- a/lib/Netdot/Model/PhysAddr.pm
+++ b/lib/Netdot/Model/PhysAddr.pm
@@ -922,7 +922,8 @@ __PACKAGE__->add_trigger( select             => \&_obj_inflate );
 # Extract first 6 characters from MAC address
 #
 sub _oui_from_address {
-    my ($self, $addr) = @_;
+    my ($class, $addr) = @_;
+    $addr = $class->format_address_db($addr);
     return substr($addr, 0, 6);
 }
 


### PR DESCRIPTION
If you use a custom MAC address format, OUI must be based on format_address_db, instead of the 6 first char of a MAC address.

This solves a display issue on /management/mac.html
