### PR TITLE
Support DHCP class type

### DIFF
--- a/etc/default_data
+++ b/etc/default_data
@@ -145,6 +145,7 @@ INSERT INTO dhcpscopetype (name) VALUES ('shared-network');
 INSERT INTO dhcpscopetype (name) VALUES ('subnet');
 INSERT INTO dhcpscopetype (name) VALUES ('host');
 INSERT INTO dhcpscopetype (name) VALUES ('template');
+INSERT INTO dhcpscopetype (name) VALUES ('class');
 
 INSERT INTO dhcpattrname (name) VALUES ('always-broadcast');
 INSERT INTO dhcpattrname (name) VALUES ('always-reply-rfc1048');

--- a/etc/netdot.meta
+++ b/etc/netdot.meta
@@ -3286,7 +3286,6 @@ $meta = {
     index => [ ['ipblock'], ['type' ], ['physaddr'] ],
     isjoin => '0',
     label => [
-      'type',
       'name'
     ],
     primary_key => 'id',

--- a/lib/Netdot/Model/DhcpScope.pm
+++ b/lib/Netdot/Model/DhcpScope.pm
@@ -721,6 +721,10 @@ sub _print {
     if ( $type ne 'global' && $type ne 'template' ){
 	my $st   = $data->{$id}->{statement};
 	my $name = $data->{$id}->{name};
+	if ( $type eq 'class' ){
+	    # DHCPD requires double quotes
+	    $name = "\"$name\"" unless $name =~ /"/;
+	}
 	print $fh $indent."$st $name {\n";
 	$indent .= " " x 4;
     }
@@ -733,6 +737,10 @@ sub _print {
     }
     
     # Print attributes
+    my %quoted_attrs = (
+	'filename' => 1,
+	'domain-name' => 1,
+	);
     foreach my $attr_id ( sort { $data->{$id}->{attrs}->{$a}->{name} cmp 
 				     $data->{$id}->{attrs}->{$b}->{name} }
 			  keys %{$data->{$id}->{attrs}} ){
@@ -743,11 +751,10 @@ sub _print {
 	my $value  = $data->{$id}->{attrs}->{$attr_id}->{value};
 	print $fh $indent.$name;
 	if ( defined $value ) {
-	    if ( defined $format && ($format eq 'text' || $format eq 'string') ){
-		# DHCPD requires double quotes
-		if ( $value !~ /^"(.*)"$/ ){
-		    $value = "\"$value\"";
-		}
+	    if ( (defined $format && ($format eq 'text' || $format eq 'string')) ||
+		exists($quoted_attrs{$name}) ){
+		# DHCPD requires double quotes for these
+		$value = "\"$value\"" unless $value =~ /"/;
 	    }
 	    print $fh " $value";
 	}

--- a/t/DhcpScope.t
+++ b/t/DhcpScope.t
@@ -27,15 +27,48 @@ isa_ok($global, 'Netdot::Model::DhcpScope', 'can insert a global scope');
 
 my $subnet = Ipblock->insert({address=>$net, status=>'Subnet'});
 $subnet->enable_dhcp(container=>$global);
+my $subnet_scope = $subnet->dhcp_scopes->first;
 
-my $scope = DhcpScope->insert(
-    {container=>$global, name=>$ip, type=>'host', 
-     ipblock=>$ip, physaddr=>$mac});
+is($subnet_scope->name, '192.168.0.0 netmask 255.255.255.0', 'Subnet scope created');
 
-isa_ok($scope, 'Netdot::Model::DhcpScope', 'can insert a host scope');
+my $host_scope = DhcpScope->insert({
+    container=>$global, type=>'host', 
+    ipblock=>$ip, physaddr=>$mac});
 
-is(DhcpScope->search(name=>$ip)->first, $scope, 'can search a scope by name' );
-is($scope->container, $global, 'scope container matches global');
+isa_ok($host_scope, 'Netdot::Model::DhcpScope', 'can insert a host scope');
+is($host_scope->name, $ip, 'host scope gets expected name');
+is(DhcpScope->search(name=>$ip)->first, $host_scope, 'can search a scope by name' );
+is(DhcpScope->search(type=>'host')->first, $host_scope, 'can search a scope by type' );
+is($host_scope->container, $global, 'scope container matches global');
+
+my $test_class_name = 'test_class_abc';
+my $class_scope = DhcpScope->insert(
+    {
+	name => $test_class_name,
+	type => 'class',
+	container => $global,
+	attributes => {
+	    'next-server' => '192.0.2.1',
+	    'filename' => '123abc'
+	}
+    }
+    );
+
+is($class_scope->name, $test_class_name, 'creates class with expected name');
+
+my ($fh, $config);
+open($fh, '>', \$config);
+my $data = DhcpScope->_get_all_data();
+DhcpScope->_print($fh, $global->id, $data);
+close($fh);
+
+my $dhcp_mac = PhysAddr->dhcpd_address($mac);
+like($config, qr/host $ip/, 'config contains host');
+like($config, qr/fixed-address $ip;/, 'config contains fixed-address statement');
+like($config, qr/hardware ethernet $dhcp_mac;/, 'config contains mac');
+like($config, qr/class "test_class_abc"/, 'config contains class');
+like($config, qr/next-server 192.0.2.1;/, 'config contains attribute');
+like($config, qr/filename "123abc";/, 'filename attribute has double quotes');
 
 &cleanup();
 


### PR DESCRIPTION
* Adds new DHCP type "class"
* Remove 'type' from the DhcpScope label in metadata
* Make sure we use double-quotes when required by ISC-DHCPD
* Augment and improve DhcpScope unit tests