### PR TITLE
Modern perl complains if you assign where it expects a boolean

### DIFF
--- a/lib/Netdot/Model/Device.pm
+++ b/lib/Netdot/Model/Device.pm
@@ -4393,7 +4393,8 @@ sub _fork_init {
 
     # Tell DBI that we don't want to disconnect the server's DB handle
     my $dbh = $class->db_Main;
-    unless ( $dbh->{InactiveDestroy} = 1 ) {
+    $dbh->{InactiveDestroy} = 1;
+    unless ( $dbh->{InactiveDestroy} == 1 ) {
 	$class->throw_fatal("Model::Device::_fork_init: Cannot set InactiveDestroy: ", $dbh->errstr);
     }
 
@@ -5398,7 +5399,8 @@ sub _launch_child {
 
     # Tell DBI that we don't want to disconnect the server's DB handle
     my $dbh = $class->db_Main;
-    unless ( $dbh->{InactiveDestroy} = 1 ) {
+    $dbh->{InactiveDestroy} = 1;
+    unless ( $dbh->{InactiveDestroy} == 1 ) {
 	$class->throw_fatal("Model::Device::_launch_child: Cannot set InactiveDestroy: ", $dbh->errstr);
     }
     # Run given code


### PR DESCRIPTION
After upgrading to Ubuntu 18.04 with perl 5.26.1-6 I started getting warnings from all netdot scripts including exporter.pl which I run from cron:

```
Found = in conditional, should be == at /usr/local/netdot/lib/Netdot/Model/Device.pm line 4335.
Found = in conditional, should be == at /usr/local/netdot/lib/Netdot/Model/Device.pm line 5340.
```

This patch silences those errors in a way which I believe follows the original intent.