### PR TITLE
Ldap proxy

### DIFF
--- a/etc/netdot_apache24_ldap.conf
+++ b/etc/netdot_apache24_ldap.conf
@@ -1,0 +1,187 @@
+# NOTE: THIS CONFIGURATION IS FOR APACHE 2.4 ONLY.
+#
+# Modify this to your liking and include it in httpd.conf.
+# -----------------------------------------------------------------------------
+
+PerlModule ModPerl::Util
+PerlModule Apache2::Request
+PerlModule Apache2::RequestRec
+PerlModule Apache2::RequestIO
+PerlModule Apache2::RequestUtil
+PerlModule Apache2::ServerUtil
+PerlModule Apache2::Connection
+PerlModule Apache2::Log
+PerlModule Apache::Session
+PerlModule APR::Table
+PerlModule ModPerl::Registry
+PerlModule "Apache2::Const => ':common'"
+PerlModule "APR::Const => ':common'"
+
+PerlModule Apache2::SiteControl
+PerlModule HTML::Mason::ApacheHandler
+
+# Uncomment this next line if you get errors from libapreq2
+# about an 'undefined symbol'
+LoadModule apreq_module /usr/lib/apache2/modules/mod_apreq2.so
+
+# Add Netdot's libraries to @INC
+PerlSwitches -I<<Make:PREFIX>>/lib
+
+<Perl>
+# Set up the Mason handler and global variables and import modules.
+use Netdot::Mason;
+
+# Override SiteControl's login method 
+use Netdot::SiteControlLoginWrapper;
+</Perl>
+
+
+# If you would like to put netdot somewhere other than ``/netdot''
+# just change this alias, the location of the login target
+# (i.e. /netdot/NetdotLogin), and the variable NetdotPath below.  
+Alias /netdot "<<Make:PREFIX>>/htdocs/"
+
+# Force UTF-8
+PerlSetVar MasonPreamble "use utf8;"
+AddDefaultCharset utf-8 
+
+# Set the path that will be protected.
+#
+# *NOTE* This variable is used to determine absolute paths where
+# needed in the netdot pages.  The Netdot corresponds to AuthName
+# Netdot below.  If you want to change the AuthName you will still
+# need this variable as the Mason code assumes you didn't change the
+# AuthName.
+PerlSetVar NetdotPath "/netdot/"
+
+# Indicate the path to the login page. Be careful, HTML::Mason can 
+# interfere with proper handling...make sure you know your dependencies.
+# See samples and Apache::AuthCookie for more information.
+PerlSetVar NetdotLoginScript /netdot/login.html
+
+# See Apache::AuthCookie for descriptions of these.  
+#
+# A general note about these Netdot variables: Some are accessed when
+# a user requests a page and others are accessed when a user attempts
+# to login.  In our setup the login target (NetdotLogin) is in the
+# same apache scope as the netdot pages (/netdot) and these variables
+# are specified at the global scope so there isn't an issue, but if
+# you decide to move them inside a Directory, Files, or Location block
+# and move the login target be sure that you put the right variables
+# in the right places (hint: you will probably have to read the
+# AuthCookie code as it is not clear from the docs, if you don't want
+# any duplicates).  The same probably goes for the SiteControl and
+# other non prefixed variables, but since they don't have prefixes it
+# would be inconsiderate to put them at the top level (pollute the
+# global name space), and so if you move the login target be sure to
+# duplicate any relevant variables (again, it might not be obvious
+# which).
+PerlSetVar NetdotSatisfy All
+# If this is set you wont be able to use unqualified hostnames and
+# rely on DNS to supply the domain.  DNS will supply the domain no
+# doubt, but the browser doesn't see it so the cookie will be invalid.
+# Also, a hostname isn't valid here.
+#PerlSetVar NetdotDomain .uoregon.edu
+PerlSetVar NetdotCache 1
+
+# We change the value of NetdotExpires dynamically to implement both
+# temporary and permanent sessions.  NetdotTemporySessionExpires
+# specifies the length of the tempory sessions, i.e. it corresponds to
+# NetdotExpires in a typical AuthCookie setup.
+PerlSetVar NetdotTemporarySessionExpires +2h
+
+<Directory <<Make:PREFIX>>/htdocs/>
+   Order Deny,Allow
+   Allow from all
+
+   # Other applications may have attempted to override how .html files are
+   # interpreted.  We need to reset this so that HTML::Mason can work 
+   # correctly.
+   AddType text/html .html
+
+   # This is hackish but it works.  It is preferred over handling all
+   # files in /netdot as this causes requests for /netdot or /netdot/
+   # to fail (DirectoryIndex doesn't get handled correctly).  The
+   # "proper" way to handle this is with rewrite rules or
+   # fixuphandlers I think, but this works: Handle everything which
+   # isn't /netdot or /netdot/, i.e. which has atleast one non / char
+   # in its name relative /netdot/, with mason.
+   <FilesMatch .>
+       SetHandler perl-script
+       PerlHandler Netdot::Mason
+   </FilesMatch>
+
+   # Prevent mason from handling css and javascript
+   <FilesMatch (\.css|\.js)$>
+       SetHandler default-handler
+   </FilesMatch>
+
+   AuthType Apache2::SiteControl
+   AuthName Netdot
+   # Choose a name for the instance of the authenticator. This name is
+   # used as part of the remaining variable names.
+   PerlSetVar AuthName Netdot
+   require valid-user
+
+   # Allow access to the css and and title image so the login page
+   # displays correctly.  The anonymous sub is somehow equiv to the
+   # specification of the constant explicitly.  The point is that you
+   # can't simply turn off authentication for particular files, you
+   # must provide a new handler which allows all requests instead.    
+   <FilesMatch (\.css|title\.png)$>
+        PerlAuthenHandler Apache2::Const::OK #'sub { return OK }'
+        PerlAuthzHandler Apache2::Const::OK #'sub { return OK }'
+   </FilesMatch>
+
+   # LDAP parameters are set in the login target Location directive
+   # below.
+   PerlSetVar SiteControlMethod Netdot::LDAP
+
+   # Turn on debugging
+   PerlSetVar AccessControllerDebug 1
+   PerlSetVar AuthCookieDebug 1
+   PerlSetVar SiteControlDebug 1
+
+   # Configure the factories. See SiteControl::UserFactory and
+   # SiteControl::ManagerFactory
+   PerlSetVar SiteControlManagerFactory Netdot::NetdotPermissionFactory
+
+   # Configure the location of the session data on server disks
+   # NOTE: apache should have read/write access to these locations. 
+   PerlSetVar SiteControlSessions <<Make:PREFIX>>/tmp/sessions
+   PerlSetVar SiteControlLocks <<Make:PREFIX>>/tmp/sessions/locks
+
+   # Tell mod_perl that you want this module to control access:
+   PerlAuthenHandler Apache2::SiteControl->authenticate
+   #PerlAuthzHandler Apache2::SiteControl->authorize
+
+   # See Apache2::SiteControl::UserFactory.  There are more variables,
+   # but this seems to be the only one which makess SiteControl insult
+   # you in the logs :P
+   PerlSetVar UserObjectPasswordKey "Netdot gets the last laugh"
+</Directory>
+
+<Location /netdot/NetdotLogin>
+   SetHandler perl-script
+   PerlHandler Netdot::SiteControlLoginWrapper->login
+
+   # Stop AuthCookie from preventing access to NetdotLogin
+   # (which would create an authen loop).
+   PerlAuthenHandler Apache2::Const::OK
+   PerlAuthzHandler Apache2::Const::OK
+
+   PerlSetVar NetdotLDAPServer  "ldaps://localhost.localdomain:636"
+   PerlSetVar NetdotLDAPServer2 "ldaps://otherhost.localdomain:636"
+   PerlSetVar NetdotLDAPRequireTLS "no"
+   PerlSetVar NetdotLDAPUserDN "uid=<username>"
+   PerlSetVar NetdotLDAPSearchBase "ou=people,dc=domain,dc=local"
+   PerlSetVar NetdotLDAPFailToLocal "yes"
+   #Set this line to "yes" if you need to do searchs to obtain ldap 
+   # user branch prior to authentication
+   PerlSetVar NetdotLDAPProxy "no"                                 
+   PerlSetVar NetdotLDAPProxySearchBaseDN "o=Org"                    
+   #Change this to the full path dn and password of the ldap user netdot can use for its search
+   PerlSetVar NetdotLDAPProxyUser "cn=ProxyNetdot,ou=USR,ou=SC,o=PA"
+   PerlSetVar NetdotLDAPProxyPass "netdot_ldap_user_password"                       
+
+</Location>

--- a/etc/netdot_apache24_ldap.conf
+++ b/etc/netdot_apache24_ldap.conf
@@ -179,9 +179,8 @@ PerlSetVar NetdotTemporarySessionExpires +2h
    #Set this line to "yes" if you need to do searchs to obtain ldap 
    # user branch prior to authentication
    PerlSetVar NetdotLDAPProxy "no"                                 
-   PerlSetVar NetdotLDAPProxySearchBaseDN "o=Org"                    
+   PerlSetVar NetdotLDAPProxySearchBaseDN "o=local"                    
    #Change this to the full path dn and password of the ldap user netdot can use for its search
-   PerlSetVar NetdotLDAPProxyUser "cn=ProxyNetdot,ou=USR,ou=SC,o=PA"
-   PerlSetVar NetdotLDAPProxyPass "netdot_ldap_user_password"                       
-
+   PerlSetVar NetdotLDAPProxyUser "cn=ProxyNetdot,ou=infr,ou=domain,o=local"
+   PerlSetVar NetdotLDAPProxyPass "ProxyNetdot_password"
 </Location>

--- a/etc/netdot_apache2_ldap.conf
+++ b/etc/netdot_apache2_ldap.conf
@@ -176,4 +176,11 @@ PerlSetVar NetdotTemporarySessionExpires +2h
    PerlSetVar NetdotLDAPUserDN "uid=<username>"
    PerlSetVar NetdotLDAPSearchBase "ou=people,dc=domain,dc=local"
    PerlSetVar NetdotLDAPFailToLocal "yes"
+   #Set this line to "yes" if you need to do searchs to obtain ldap 
+   # user branch prior to authentication
+   PerlSetVar NetdotLDAPProxy "no"                                 
+   PerlSetVar NetdotLDAPProxySearchBaseDN "o=local"                    
+   #Change this to the full path dn and password of the ldap user netdot can use for its search
+   PerlSetVar NetdotLDAPProxyUser "cn=ProxyNetdot,ou=infr,ou=domain,o=local"
+   PerlSetVar NetdotLDAPProxyPass "ProxyNetdot_password"
 </Location>

--- a/lib/Netdot/LDAP.pm
+++ b/lib/Netdot/LDAP.pm
@@ -25,6 +25,11 @@ In Apache configuration:
       PerlSetVar NetdotLDAPVersion "3"
       PerlSetVar NetdotLDAPCACert "/usr/local/ssl/certs/cacert.pem"
       PerlSetVar NetdotLDAPFailToLocal "yes"
+      PerlSetVar NetdotLDAPProxy "no"
+      PerlSetVar NetdotLDAPProxySearchBaseDN "o=local"
+      #Change this to the full path dn and password of the ldap user netdot can use for its search
+      PerlSetVar NetdotLDAPProxyUser "cn=ProxyNetdot,ou=infr,ou=domain,o=local"
+      PerlSetVar NetdotLDAPProxyPass "ProxyNetdot_password"
    </Location>
     
 =back
@@ -67,6 +72,21 @@ NetdotLDAPVersion
 NetdotLDAPFailToLocal <yes|no>
     If LDAP authentication fails, authenticate against local (Netdot DB) credentials.
     
+NetdotLDAPProxy <yes|no>
+    If the LDAP server, does not allow anonymous binding, and users, reside in more than one branch, Netdot needs to use a initial login/password to connecto to LDAP server and search for the user's branch to be able to contruct the final distinguished name (DN) for the user. Just leave it at "no", if this is not needed.
+
+NetdotLDAPProxySearchBaseDN
+    The user will ne searched on the ldap Tree, down this top boundary. It can be the top of the tree, or a more specific brach, as needed.
+    e.g.1. "o=MY" 
+    e.g.2. "ou=TI,ou=EMP,o=MY"
+
+NetdotLDAPProxyUser 
+    Username, used by Netdot to login in the LDAP server. This should be the complete DN of the user.
+   e.g. "cn=ProxyNetdot,ou=USR,ou=IFR,o=MY"
+
+NetdotLDAPProxyPass
+    Password to login on the LDAP server.
+   e.g. "oij98uiu34eiuhs9"
 =cut
 
 ##########################################################################################


### PR DESCRIPTION
Allow Netdot to connect to LDAP servers that don't permit anonymous binding, and also scenarios where LDAP users reside on more than one branch. This adds a bit of code to use a "proxy" user, to do a first authenticated connection to LDAP server to locate the branch where user resides, after authenticaction of user procedes as it did before theis change. Also provides an Apache 2.4 configuration version with LDAP authentication.