### PR TITLE
Added CLI support getting ARP for Netscreen, and ARP and FWT for JunOS and H3C.

### DIFF
--- a/etc/Default.conf
+++ b/etc/Default.conf
@@ -524,6 +524,9 @@ FETCH_DEVICE_INFO_VIA_CLI => {
     '^snFWS648G'            => 'FoundryIW',
     '^snTI2X24'             => 'FoundryIW',
     '^snFastIronStackICX'   => 'FoundryIW',
+    '^netscreen'            => 'Netscreen',
+#    '^hpA5500.*'            => 'H3C',
+#    '^jnxProductNameEX4\d{3}'   => 'JunOS',    
 },
 
 # Device CLI credentials.  These are used for fetching

--- a/lib/Netdot/Meta.pm
+++ b/lib/Netdot/Meta.pm
@@ -27,6 +27,9 @@ my %DERIVED_CLASSES = (
     'CiscoCat'  => ['Netdot::Model::Device::CLI::CiscoCat',  'Netdot::Model::Device'],
     'FoundryIW' => ['Netdot::Model::Device::CLI::FoundryIW', 'Netdot::Model::Device'],
     'Airespace' => ['Netdot::Model::Device::Airespace',      'Netdot::Model::Device'],
+    'Netscreen' => ['Netdot::Model::Device::CLI::Netscreen', 'Netdot::Model::Device'],
+    'H3C'       => ['Netdot::Model::Device::CLI::H3C',       'Netdot::Model::Device'],
+    'JunOS'     => ['Netdot::Model::Device::CLI::JunOS',     'Netdot::Model::Device'],
     );
 
 # Some private class data and related methods

--- a/lib/Netdot/Model/Device/CLI/H3C.pm
+++ b/lib/Netdot/Model/Device/CLI/H3C.pm
@@ -1,0 +1,349 @@
+#ciscoIOS.pm based
+package Netdot::Model::Device::CLI::H3C;
+
+
+use base 'Netdot::Model::Device::CLI';
+use warnings;
+use strict;
+use Net::Appliance::Session;
+
+my $logger = Netdot->log->get_logger('Netdot::Model::Device');
+
+# Some regular expressions
+my $IPV4 = Netdot->get_ipv4_regex();
+my $IPV6 = Netdot->get_ipv6_regex();
+my $H3C_MAC = '\w{4}-\w{4}-\w{4}';
+
+=head1 NAME
+
+Netdot::Model::Device::CLI::H3C - H3C Class
+
+=head1 SYNOPSIS
+
+ Overrides certain methods from the Device class. More Specifically, methods in 
+ this class try to obtain forwarding tables and ARP/ND caches via CLI
+ instead of via SNMP.
+
+=head1 INSTANCE METHODS
+=cut
+
+############################################################################
+
+=head2 get_arp - Fetch ARP tables
+
+  Arguments:
+    session - SNMP session (optional)
+  Returns:
+    Hashref
+  Examples:
+    my $cache = $self->get_arp(%args)
+=cut
+
+sub get_arp {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('get_arp');
+    my $host = $self->fqdn;
+
+    unless ( $self->collect_arp ){
+	$logger->debug(sub{"Device::H3C::_get_arp: $host excluded from ARP collection. Skipping"});
+	return;
+    }
+    if ( $self->is_in_downtime ){
+	$logger->debug(sub{"Device::H3C::_get_arp: $host in downtime. Skipping"});
+	return;
+    }
+
+    ## This will hold both ARP and v6 ND caches
+    my %cache;
+
+    ### v4 ARP
+    my $start = time;
+    my $arp_count = 0;
+    my $arp_cache = $self->_get_arp_from_cli(host=>$host) ||
+	$self->_get_arp_from_snmp(session=>$argv{session});
+    foreach ( keys %$arp_cache ){
+	$cache{'4'}{$_} = $arp_cache->{$_};
+	$arp_count+= scalar(keys %{$arp_cache->{$_}})
+    }
+    my $end = time;
+    $logger->info(sub{ sprintf("$host: ARP cache fetched. %s entries in %s", 
+			       $arp_count, $self->sec2dhms($end-$start) ) });
+    
+
+    if ( $self->config->get('GET_IPV6_ND') ){
+	### v6 ND
+	$start = time;
+	my $nd_count = 0;
+	my $nd_cache  = $self->_get_v6_nd_from_cli(host=>$host) ||
+	    $self->_get_v6_nd_from_snmp($argv{session});
+	# Here we have to go one level deeper in order to
+	# avoid losing the previous entries
+	foreach ( keys %$nd_cache ){
+	    foreach my $ip ( keys %{$nd_cache->{$_}} ){
+		$cache{'6'}{$_}{$ip} = $nd_cache->{$_}->{$ip};
+		$nd_count++;
+	    }
+	}
+	$end = time;
+	$logger->info(sub{ sprintf("$host: IPv6 ND cache fetched. %s entries in %s", 
+				   $nd_count, $self->sec2dhms($end-$start) ) });
+    }
+
+    return \%cache;
+}
+
+############################################################################
+
+=head2 get_fwt - Fetch forwarding tables
+
+  Arguments:
+    session - SNMP session (optional)    
+  Returns:
+    Hashref
+  Examples:
+    my $fwt = $self->get_fwt(%args)
+=cut
+
+sub get_fwt {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('get_fwt');
+    my $host = $self->fqdn;
+    my $fwt = {};
+
+    unless ( $self->collect_fwt ){
+	$logger->debug(sub{"Device::H3C::get_fwt: $host excluded from FWT collection. Skipping"});
+	return;
+    }
+    if ( $self->is_in_downtime ){
+	$logger->debug(sub{"Device::H3C::get_fwt: $host in downtime. Skipping"});
+	return;
+    }
+
+    my $start     = time;
+    my $fwt_count = 0;
+    
+    # Try CLI, and then SNMP 
+    $fwt = $self->_get_fwt_from_cli(host=>$host) ||
+	$self->_get_fwt_from_snmp(session=>$argv{session});
+
+    map { $fwt_count+= scalar(keys %{$fwt->{$_}}) } keys %$fwt;
+    my $end = time;
+    $logger->debug(sub{ sprintf("$host: FWT fetched. %s entries in %s", 
+				$fwt_count, $self->sec2dhms($end-$start) ) });
+   return $fwt;
+
+}
+
+
+############################################################################
+#_get_arp_from_cli - Fetch ARP tables via CLI
+#    
+#   Arguments:
+#     host
+#   Returns:
+#     Hash ref.
+#   Examples:
+#     $self->_get_arp_from_cli(host=>'foo');
+#
+sub _get_arp_from_cli {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('_get_arp_from_cli');
+
+    my $host = $argv{host};
+    my $args = $self->_get_credentials(host=>$host);
+    return unless ref($args) eq 'HASH';
+
+    my @output = $self->_cli_cmd(%$args, host=>$host, personality=>'h3c', cmd=>'display arp' );
+
+    my %cache;
+    shift @output; # Ignore header line
+    # Lines look like this:
+    # Internet  10.82.250.129           -   0000.0c9f.f002  ARPA   GigabitEthernet0/3.2335
+    #10.36.1.65       cc3e-5f4c-1053  10       BAGG1                  18    D
+    foreach my $line ( @output ) {
+	my ($iname, $ip, $mac, $intid);
+	chomp($line);
+	if ( $line =~ /^($IPV4)\s+($H3C_MAC)\s+\d+\s+(\S+)\s+\d+\s+\S+\s*$/o ) {
+	    $ip    = $1;
+	    $mac   = $2;
+	    $iname = $3;
+            $iname =~ s/BAGG/Bridge-Aggregation/g;
+	}else{
+	    $logger->debug(sub{"Device::CLI::H3C::_get_arp_from_cli: line did not match criteria: $line" });
+	    next;
+	}
+	unless ( $ip && $mac && $iname ){
+	    $logger->debug(sub{"Device::H3C::_get_arp_from_cli: Missing information: $line" });
+	    next;
+	}
+	$cache{$iname}{$ip} = $mac;
+    }
+    return $self->_validate_arp(\%cache, 4);
+}
+
+############################################################################
+#_get_v6_nd_from_cli - Fetch ARP tables via CLI
+#    
+#   Arguments:
+#     host
+#   Returns:
+#     Hash ref.
+#   Examples:
+#     $self->_get_v6_nd_from_cli(host=>'foo');
+#
+sub _get_v6_nd_from_cli {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('_get_v6_nd_from_cli');
+
+    my $host = $argv{host};
+    my $args = $self->_get_credentials(host=>$host);
+    return unless ref($args) eq 'HASH';
+
+    my @output = $self->_cli_cmd(%$args, host=>$host, cmd=>'show ipv6 neighbors', personality=>'h3c');
+    shift @output; # Ignore header line
+    my %cache;
+    foreach my $line ( @output ) {
+	my ($ip, $mac, $iname);
+	chomp($line);
+	# Lines look like this:
+	# FE80::219:E200:3B7:1920                     0 0019.e2b7.1920  REACH Gi0/2.3
+	if ( $line =~ /^($IPV6)\s+\d+\s+($H3C_MAC)\s+\S+\s+(\S+)/o ) {
+	    $ip    =  $1;
+	    $mac   =  $2;
+            $mac   =~ s/-/:/g;
+	    $iname =  $3;
+	}else{
+	    $logger->debug(sub{"Device::CLI::H3C::_get_v6_nd_from_cli: line did not match criteria: $line" });
+	    next;
+	}
+	unless ( $iname && $ip && $mac ){
+	    $logger->debug(sub{"Device::H3C::_get_v6_nd_from_cli: Missing information: $line"});
+	    next;
+	}
+	$cache{$iname}{$ip} = $mac;
+    }
+    return $self->_validate_arp(\%cache, 6);
+}
+
+############################################################################
+#_get_fwt_from_cli - Fetch forwarding tables via CLI
+#
+#    
+#   Arguments:
+#     host
+#   Returns:
+#     Hash ref.
+#    
+#   Examples:
+#     $self->_get_fwt_from_cli();
+#
+#
+sub _get_fwt_from_cli {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('_get_fwt_from_cli');
+
+    my $host = $argv{host};
+    my $args = $self->_get_credentials(host=>$host);
+    return unless ref($args) eq 'HASH';
+
+    my @output = $self->_cli_cmd(%$args, host=>$host, cmd=>'display mac-address', personality=>'h3c');
+
+    shift @output; # Ignore header line
+
+    # MAP interface names to IDs
+    my %int_names;
+    foreach my $int ( $self->interfaces ){
+	my $name = $self->_reduce_iname($int->name);
+	$int_names{$name} = $int->id;
+    }
+    
+
+    my ($iname, $mac, $intid);
+    my %fwt;
+    
+    # Output look like this:
+    #MAC ADDR       VLAN ID  STATE          PORT INDEX               AGING TIME(s)
+    #3c61-0472-6eb2 1        Learned        Bridge-Aggregation1      AGING
+    #f4b5-2f9f-bd4d 1        Learned        Bridge-Aggregation1      AGING
+
+
+    foreach my $line ( @output ) {
+	chomp($line);
+	if ( $line =~ /^\s*($H3C_MAC)\s+\S+\s+\S+\s+(\S+)\s+\S+\s*$/o ) {
+	    $mac   = $1;
+	    $iname = $2;
+            $mac =~ s/-/:/g;
+	}elsif ( $line =~ /^.*($H3C_MAC)\s+\S+\s+\S+\s+(\S+)\s+\S+\s*$/o ) {
+	    $mac   = $1;
+	    $iname = $2;
+	}else{
+	    $logger->debug(sub{"Device::CLI::H3C::_get_fwt_from_cli: line did not match criteria: '$line'" });
+	    next;
+	}
+	$iname = $self->_reduce_iname($iname);
+	my $intid = $int_names{$iname};
+
+	unless ( $intid ) {
+	    $logger->warn("Device::CLI::H3C::_get_fwt_from_cli: $host: Could not match $iname to any interface names");
+	    next;
+	}
+	
+	my $validmac = PhysAddr->validate($mac);
+	if ( $validmac ){
+	    $mac = $validmac;
+	}else{
+	    $logger->debug(sub{"Device::CLI::H3C::_get_fwt_from_cli: $host: Invalid MAC: $mac" });
+	    next;
+	}	
+
+	# Store in hash
+	$fwt{$intid}{$mac} = 1;
+	$logger->debug(sub{"Device::CLI::H3C::_get_fwt_from_cli: $host: $iname -> $mac" });
+    }
+    
+    return \%fwt;
+}
+
+
+############################################################################
+# _reduce_iname
+#  Convert "GigabitEthernet0/3 into "Gi0/3" to match the different formats
+#
+# Arguments: 
+#   string
+# Returns:
+#   string
+#
+sub _reduce_iname{
+    my ($self, $name) = @_;
+    return unless $name;
+    $name =~ s/^(\w{2})\S*?([\d\/]+).*/$1$2/;
+    return $name;
+}
+
+=head1 AUTHOR
+
+Carlos Vicente, C<< <cvicente at ns.uoregon.edu> >>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2011 University of Oregon, all rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+=cut
+
+#Be sure to return 1
+1;

--- a/lib/Netdot/Model/Device/CLI/JunOS.pm
+++ b/lib/Netdot/Model/Device/CLI/JunOS.pm
@@ -1,0 +1,353 @@
+#ciscoIOS.pm based
+package Netdot::Model::Device::CLI::JunOS;
+
+
+use base 'Netdot::Model::Device::CLI';
+use warnings;
+use strict;
+use Net::Appliance::Session;
+
+my $logger = Netdot->log->get_logger('Netdot::Model::Device');
+
+# Some regular expressions
+my $IPV4 = Netdot->get_ipv4_regex();
+my $IPV6 = Netdot->get_ipv6_regex();
+my $JUNOS_MAC = '\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2}';
+
+=head1 NAME
+
+Netdot::Model::Device::CLI::JunOS - JunOS Class
+
+=head1 SYNOPSIS
+
+ Overrides certain methods from the Device class. More Specifically, methods in 
+ this class try to obtain forwarding tables and ARP/ND caches via CLI
+ instead of via SNMP.
+
+=head1 INSTANCE METHODS
+=cut
+
+############################################################################
+
+=head2 get_arp - Fetch ARP tables
+
+  Arguments:
+    session - SNMP session (optional)
+  Returns:
+    Hashref
+  Examples:
+    my $cache = $self->get_arp(%args)
+=cut
+
+sub get_arp {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('get_arp');
+    my $host = $self->fqdn;
+
+    unless ( $self->collect_arp ){
+	$logger->debug(sub{"Device::H3C::_get_arp: $host excluded from ARP collection. Skipping"});
+	return;
+    }
+    if ( $self->is_in_downtime ){
+	$logger->debug(sub{"Device::H3C::_get_arp: $host in downtime. Skipping"});
+	return;
+    }
+
+    ## This will hold both ARP and v6 ND caches
+    my %cache;
+
+    ### v4 ARP
+    my $start = time;
+    my $arp_count = 0;
+    my $arp_cache = $self->_get_arp_from_cli(host=>$host) ||
+	$self->_get_arp_from_snmp(session=>$argv{session});
+    foreach ( keys %$arp_cache ){
+	$cache{'4'}{$_} = $arp_cache->{$_};
+	$arp_count+= scalar(keys %{$arp_cache->{$_}})
+    }
+    my $end = time;
+    $logger->info(sub{ sprintf("$host: ARP cache fetched. %s entries in %s", 
+			       $arp_count, $self->sec2dhms($end-$start) ) });
+    
+
+    if ( $self->config->get('GET_IPV6_ND') ){
+	### v6 ND
+	$start = time;
+	my $nd_count = 0;
+	my $nd_cache  = $self->_get_v6_nd_from_cli(host=>$host) ||
+	    $self->_get_v6_nd_from_snmp($argv{session});
+	# Here we have to go one level deeper in order to
+	# avoid losing the previous entries
+	foreach ( keys %$nd_cache ){
+	    foreach my $ip ( keys %{$nd_cache->{$_}} ){
+		$cache{'6'}{$_}{$ip} = $nd_cache->{$_}->{$ip};
+		$nd_count++;
+	    }
+	}
+	$end = time;
+	$logger->info(sub{ sprintf("$host: IPv6 ND cache fetched. %s entries in %s", 
+				   $nd_count, $self->sec2dhms($end-$start) ) });
+    }
+
+    return \%cache;
+}
+
+############################################################################
+
+=head2 get_fwt - Fetch forwarding tables
+
+  Arguments:
+    session - SNMP session (optional)    
+  Returns:
+    Hashref
+  Examples:
+    my $fwt = $self->get_fwt(%args)
+=cut
+
+sub get_fwt {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('get_fwt');
+    my $host = $self->fqdn;
+    my $fwt = {};
+
+    unless ( $self->collect_fwt ){
+	$logger->debug(sub{"Device::H3C::get_fwt: $host excluded from FWT collection. Skipping"});
+	return;
+    }
+    if ( $self->is_in_downtime ){
+	$logger->debug(sub{"Device::H3C::get_fwt: $host in downtime. Skipping"});
+	return;
+    }
+
+    my $start     = time;
+    my $fwt_count = 0;
+    
+    # Try CLI, and then SNMP 
+    $fwt = $self->_get_fwt_from_cli(host=>$host) ||
+	$self->_get_fwt_from_snmp(session=>$argv{session});
+
+    map { $fwt_count+= scalar(keys %{$fwt->{$_}}) } keys %$fwt;
+    my $end = time;
+    $logger->debug(sub{ sprintf("$host: FWT fetched. %s entries in %s", 
+				$fwt_count, $self->sec2dhms($end-$start) ) });
+   return $fwt;
+
+}
+
+
+############################################################################
+#_get_arp_from_cli - Fetch ARP tables via CLI
+#    
+#   Arguments:
+#     host
+#   Returns:
+#     Hash ref.
+#   Examples:
+#     $self->_get_arp_from_cli(host=>'foo');
+#
+sub _get_arp_from_cli {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('_get_arp_from_cli');
+
+    my $host = $argv{host};
+    my $args = $self->_get_credentials(host=>$host);
+    return unless ref($args) eq 'HASH';
+
+    my @output = $self->_cli_cmd(%$args, host=>$host, personality=>'junos', cmd=>'show arp' );
+
+    my %cache;
+    shift @output; # Ignore header line
+    # Lines look like this:
+    #MAC Address       Address         Name                      Interface               Flags
+    #3c:61:04:fb:69:01 10.36.0.1       10.36.0.1                 vlan.10                 none
+    foreach my $line ( @output ) {
+	my ($iname, $ip, $mac, $intid);
+	chomp($line);
+	if ( $line =~ /^($JUNOS_MAC)\s+($IPV4)\s+\S+\s+(\S+)\s+\S+\s*$/o ) {
+	    $mac    = $1;
+	    $ip   = $2;
+	    $iname = $3;
+	}else{
+	    $logger->debug(sub{"Device::CLI::JunOS::_get_arp_from_cli: line did not match criteria: $line" });
+	    next;
+	}
+	unless ( $ip && $mac && $iname ){
+	    $logger->debug(sub{"Device::H3C::_get_arp_from_cli: Missing information: $line" });
+	    next;
+	}
+	$cache{$iname}{$ip} = $mac;
+    }
+    return $self->_validate_arp(\%cache, 4);
+}
+
+############################################################################
+#_get_v6_nd_from_cli - Fetch ARP tables via CLI
+#    
+#   Arguments:
+#     host
+#   Returns:
+#     Hash ref.
+#   Examples:
+#     $self->_get_v6_nd_from_cli(host=>'foo');
+#
+sub _get_v6_nd_from_cli {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('_get_v6_nd_from_cli');
+
+    my $host = $argv{host};
+    my $args = $self->_get_credentials(host=>$host);
+    return unless ref($args) eq 'HASH';
+
+    my @output = $self->_cli_cmd(%$args, host=>$host, cmd=>'show ipv6 neighbors', personality=>'junos');
+    shift @output; # Ignore header line
+    my %cache;
+    foreach my $line ( @output ) {
+	my ($ip, $mac, $iname);
+	chomp($line);
+	# Lines look like this:
+	#Ethernet-switching table: 1739 entries, 1716 learned, 0 persistent entries
+	#  VLAN              MAC address       Type         Age Interfaces
+ 	#  OV9E-CUARENTENA-INFRAESTRUC *       Flood          - All-members
+ 	#  OV9E-ECAMARAS-VIGI *                Flood          - All-members
+ 	#  OV9E-ECAMARAS-VIGI 54:c4:15:3f:26:bf Learn         0 ae30.0
+	if ( $line =~ /^($IPV6)\s+\d+\s+($JUNOS_MAC)\s+\S+\s+(\S+)/o ) {
+	    $ip    =  $1;
+	    $mac   =  $2;
+            $mac   =~ s/-/:/g;
+	    $iname =  $3;
+	}else{
+	    $logger->debug(sub{"Device::CLI::JunOS::_get_v6_nd_from_cli: line did not match criteria: $line" });
+	    next;
+	}
+	unless ( $iname && $ip && $mac ){
+	    $logger->debug(sub{"Device::H3C::_get_v6_nd_from_cli: Missing information: $line"});
+	    next;
+	}
+	$cache{$iname}{$ip} = $mac;
+    }
+    return $self->_validate_arp(\%cache, 6);
+}
+
+############################################################################
+#_get_fwt_from_cli - Fetch forwarding tables via CLI
+#
+#    
+#   Arguments:
+#     host
+#   Returns:
+#     Hash ref.
+#    
+#   Examples:
+#     $self->_get_fwt_from_cli();
+#
+#
+sub _get_fwt_from_cli {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('_get_fwt_from_cli');
+
+    my $host = $argv{host};
+    my $args = $self->_get_credentials(host=>$host);
+    return unless ref($args) eq 'HASH';
+
+    my @output = $self->_cli_cmd(%$args, host=>$host, cmd=>'show ethernet-switching table brief', personality=>'junos');
+
+    shift @output; # Ignore header line
+
+    # MAP interface names to IDs
+    my %int_names;
+    foreach my $int ( $self->interfaces ){
+	my $name = $self->_reduce_iname($int->name);
+	$int_names{$name} = $int->id;
+    }
+    
+
+    my ($iname, $mac, $intid);
+    my %fwt;
+    
+    # Output look like this:
+    #Ethernet-switching table: 1739 entries, 1716 learned, 0 persistent entries
+    #  VLAN              MAC address       Type         Age Interfaces
+    #  OV9E-CUARENTENA-INFRAESTRUC *       Flood          - All-members
+    #  OV9E-ECAMARAS-VIGI *                Flood          - All-members
+    #  OV9E-ECAMARAS-VIGI 54:c4:15:3f:26:bf Learn         0 ae30.0
+
+    foreach my $line ( @output ) {
+	chomp($line);
+	if ( $line =~ /^\s+\S+\s+($JUNOS_MAC)\s+\S+\s+\S+\s+(\S+)\s*$/o ) {
+	    $mac   = $1;
+	    $iname = $2;
+            $mac =~ s/(\w{2}):(\w{2}):(\w{2}):(\w{2}):(\w{2}):(\w{2})/$1$2:$3$4:$5$6/g;
+	}elsif ( $line =~ /^.*($JUNOS_MAC)\s+\S+\s+\S+\s+(\S+)\s+\S+\s*$/o ) {
+	    $mac   = $1;
+	    $iname = $2;
+	}else{
+	    $logger->debug(sub{"Device::CLI::JunOS::_get_fwt_from_cli: line did not match criteria: '$line'" });
+	    next;
+	}
+	$iname = $self->_reduce_iname($iname);
+	my $intid = $int_names{$iname};
+
+	unless ( $intid ) {
+	    $logger->warn("Device::CLI::JunOS::_get_fwt_from_cli: $host: Could not match $iname to any interface names");
+	    next;
+	}
+	
+	my $validmac = PhysAddr->validate($mac);
+	if ( $validmac ){
+	    $mac = $validmac;
+	}else{
+	    $logger->debug(sub{"Device::CLI::JunOS::_get_fwt_from_cli: $host: Invalid MAC: $mac" });
+	    next;
+	}	
+
+	# Store in hash
+	$fwt{$intid}{$mac} = 1;
+	$logger->debug(sub{"Device::CLI::JunOS::_get_fwt_from_cli: $host: $iname -> $mac" });
+    }
+    
+    return \%fwt;
+}
+
+
+############################################################################
+# _reduce_iname
+#  Convert "GigabitEthernet0/3 into "Gi0/3" to match the different formats
+#
+# Arguments: 
+#   string
+# Returns:
+#   string
+#
+sub _reduce_iname{
+    my ($self, $name) = @_;
+    return unless $name;
+    $name =~ s/^(\w{2})\S*?([\d\/]+).*/$1$2/;
+    return $name;
+}
+
+=head1 AUTHOR
+
+Carlos Vicente, C<< <cvicente at ns.uoregon.edu> >>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2011 University of Oregon, all rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+=cut
+
+#Be sure to return 1
+1;

--- a/lib/Netdot/Model/Device/CLI/Netscreen.pm
+++ b/lib/Netdot/Model/Device/CLI/Netscreen.pm
@@ -1,0 +1,264 @@
+package Netdot::Model::Device::CLI::Netscreen;
+
+use base 'Netdot::Model::Device::CLI';
+use warnings;
+use strict;
+use Net::Appliance::Session;
+
+my $logger = Netdot->log->get_logger('Netdot::Model::Device');
+
+# Some regular expressions
+my $IPV4 = Netdot->get_ipv4_regex();
+my $IPV6 = Netdot->get_ipv6_regex();
+my $NETSCREEN_MAC =  '\w{12}';
+
+=head1 NAME
+
+Netdot::Model::Device::CLI::Netscreen - Cisco Firewall Class
+
+=head1 SYNOPSIS
+
+ Overrides certain methods from the Device class. Specifically, methods in 
+ this class try to obtain forwarding tables and ARP/ND caches via CLI
+ instead of via SNMP.
+
+=head1 INSTANCE METHODS
+=cut
+
+############################################################################
+
+=head2 get_arp - Fetch ARP tables
+
+  Arguments:
+    session - SNMP session (optional)
+  Returns:
+    Hashref
+  Examples:
+    my $cache = $self->get_arp(%args)
+=cut
+
+sub get_arp {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('get_arp');
+    my $host = $self->fqdn;
+
+    unless ( $self->collect_arp ){
+	$logger->debug(sub{"Device::Netscreen::_get_arp: $host excluded from ARP collection. Skipping"});
+	return;
+    }
+    if ( $self->is_in_downtime ){
+	$logger->debug(sub{"Device::Netscreen::_get_arp: $host in downtime. Skipping"});
+	return;
+    }
+
+    # This will hold both ARP and v6 ND caches
+    my %cache;
+
+    ### v4 ARP
+    my $start = time;
+    my $arp_count = 0;
+    my $arp_cache = $self->_get_arp_from_cli(host=>$host) ||
+	$self->_get_arp_from_snmp(session=>$argv{session});
+    foreach ( keys %$arp_cache ){
+	$cache{'4'}{$_} = $arp_cache->{$_};
+	$arp_count+= scalar(keys %{$arp_cache->{$_}})
+    }
+    my $end = time;
+    $logger->info(sub{ sprintf("$host: ARP cache fetched. %s entries in %s", 
+			       $arp_count, $self->sec2dhms($end-$start) ) });
+    
+
+    if ( $self->config->get('GET_IPV6_ND') ){
+	### v6 ND
+	$start = time;
+	my $nd_count = 0;
+	my $nd_cache  = $self->_get_v6_nd_from_cli(host=>$host) ||
+	    $self->_get_v6_nd_from_snmp($argv{session});
+	# Here we have to go one level deeper in order to
+	# avoid losing the previous entries
+	foreach ( keys %$nd_cache ){
+	    foreach my $ip ( keys %{$nd_cache->{$_}} ){
+		$cache{'6'}{$_}{$ip} = $nd_cache->{$_}->{$ip};
+		$nd_count++;
+	    }
+	}
+	$end = time;
+	$logger->info(sub{ sprintf("$host: IPv6 ND cache fetched. %s entries in %s", 
+				   $nd_count, $self->sec2dhms($end-$start) ) });
+    }
+
+    return \%cache;
+}
+
+############################################################################
+#_get_arp_from_cli - Fetch ARP tables via CLI
+#
+#    
+#   Arguments:
+#     host
+#   Returns:
+#     Hash ref.
+#   Examples:
+#     $self->_get_arp_from_cli();
+#
+#
+sub _get_arp_from_cli {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('_get_arp_from_cli');
+
+    my $host = $argv{host};
+    my $args = $self->_get_credentials(host=>$host);
+
+#    my @output = $self->_cli_cmd(%$args, host=>$host, cmd=>'show arp', personality=>'pixos');
+    my @output = $self->_cli_cmd(%$args, host=>$host, cmd=>'get arp', personality=>'screenos');
+    
+    my %cache;
+    my ($iname, $ip, $mac, $intid);
+    # Lines look like this:
+    # outside 10.10.47.146 0026.9809.f642 251
+    #######
+    #             IP           Mac          VR/Interface  State   Age  Retry  PakQue  Sess_cnt
+    #-----------------------------------------------------------------------------------------
+    #10.97.160.99  001a6ca5413f  trust-vr/eth3/1.1500    VLD   505      0       0     0
+    ####### Arp entries on AIC Chip(s)
+    #L2idx  IP               Dst_Mac(la buena)       Interface        Src_Mac(la del interface?)       Vlan  Sat  Flag  Ref_cnt
+    #8890   10.60.112.17     001372918a1d  eth2/5.11        0010dbff40b0  11    0     0x2    0
+    foreach my $line ( @output ) {
+        # strip the virtual router name from the interface names
+	if ( $line =~ /^\s*($IPV4)\s*($NETSCREEN_MAC)\s*\S*(eth|mgt)([a-zA-Z\/0-9\.-]*)\s*.*$/
+		) {
+   	if ( $3 eq 'eth' ) {
+  		$iname = "ethernet".$4;
+		}
+            elsif ( $3 eq 'mgt' ) {
+		$iname = "mgt".$4 ;
+		}
+   		$ip    = $1;
+   		$mac   = $2;
+	}elsif ( $line =~/^\d*\s*($IPV4)\s*($NETSCREEN_MAC)\s*(eth|mgt)([a-zA-Z\/0-9\.-]*).*$/
+		){
+		   # The 'dns domain-lookup outside' option causes outside-facing entries
+		   # to be reported as hostnames
+		   if ( $3 eq 'eth' ) {
+			  $iname = "ethernet".$4;
+			}
+	           elsif ( $3 eq 'mgt' ) {
+			$iname = "mgt".$4 ;
+			}
+            	$ip = $1;
+		$mac = $2;
+	}else{
+   		$logger->debug(sub{"Device::CLI::Netscreen::_get_arp_from_cli: line did not match criteria: "."$line" });
+   		next;
+		}	
+	# The failover interface appears in the arp output but it's not in the IF-MIB output
+	next if ($iname eq 'failover');
+
+	unless ( $ip && $mac && $iname ){
+	    $logger->debug(sub{"Device::Netscreen::_get_arp_from_cli: Missing information: $line" });
+	    next;
+	}
+
+	# Store in hash
+	$cache{$iname}{$ip} = $mac;
+    }
+    return $self->_validate_arp(\%cache, 4);
+}
+
+
+
+############################################################################
+#_get_v6_nd_from_cli - Fetch ARP tables via CLI
+#    
+#   Arguments:
+#     host
+#   Returns:
+#     Hash ref.
+#   Examples:
+#     $self->_get_v6_nd_from_cli(host=>'foo');
+#
+sub _get_v6_nd_from_cli {
+    my ($self, %argv) = @_;
+    $self->isa_object_method('_get_v6_nd_from_cli');
+
+    my $host = $argv{host};
+    my $args = $self->_get_credentials(host=>$host);
+    return unless ref($args) eq 'HASH';
+
+    my @output = $self->_cli_cmd(%$args, host=>$host, cmd=>'show ipv6 neighbor', personality=>'pixos');
+    shift @output; # Ignore header line
+    my %cache;
+    foreach my $line ( @output ) {
+	my ($ip, $mac, $iname);
+	chomp($line);
+	# Lines look like this:
+	# fe80::224:e8ff:fe51:6abe                    0 0024.e851.6abe  REACH dmz
+	if ( $line =~ /^($IPV6)\s+\d+\s+($NETSCREEN_MAC)\s+\S+\s+(\S+)/o ) {
+	    $ip    = $1;
+	    $mac   = $2;
+	    $iname = $3;
+	}else{
+	    $logger->debug(sub{"Device::CLI::Netscreen::_get_v6_nd_from_cli: ".
+				   "line did not match criteria: $line" });
+	    next;
+	}
+	unless ( $iname && $ip && $mac ){
+	    $logger->debug(sub{"Device::Netscreen::_get_v6_nd_from_cli: Missing information: $line"});
+	    next;
+	}
+	$cache{$iname}{$ip} = $mac;
+    }
+    return $self->_validate_arp(\%cache, 6);
+}
+
+
+############################################################################
+# _reduce_iname
+#
+# Interface names from SNMP are stupidly long and don't match the short name 
+# in the ARP output so we have to do some pattern matching. Of course, this 
+# will break when they decide to change the string.
+#
+# Arguments: 
+#   string
+# Returns:
+#   string
+#
+
+sub _reduce_iname{
+    my ($self, $name) = @_;
+    return unless $name;
+    if ( $name =~ /.*eth(.*)/ ){
+return "eth".$1;
+    }elsif ( $name =~ /.*mgt(.*)/ ){
+return "mgt".$1;
+    }
+    return $name;
+}
+
+=head1 AUTHOR
+
+Carlos Vicente, C<< <cvicente at ns.uoregon.edu> >>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2012 University of Oregon, all rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+=cut
+
+#Be sure to return 1
+1;


### PR DESCRIPTION
The usage seems mandatory to get ARP from Netscreen.
For JunOS and H3C data can be obtained (and faster in my tests) via
SNMP, so it's use is commented in Default.conf, uncommented if needed.
Only tested with IPv4, may not work as is with IPv6.

Tested on:
Netscreen -> Netscreen-5400 (juniper Ns5000).
JunOS -> Juniper Networks EX4550 (JunOS).
H3C -> HP A5500

Note: For H3C to work it a phrasebook needs to be added to
Net-CLI-Interact.
In my case:
/usr/share/perl5/auto/share/dist/Net-CLI-Interact/phrasebook/h3c/pb
Contents of
/usr/share/perl5/auto/share/dist/Net-CLI-Interact/phrasebook/h3c/pb:
prompt generic
    match />\s*$/

prompt privileged
    match /\# ?$/

prompt configure
    match /\(config[^)]*\)\# ?$/

prompt user
    match /[Uu]sername: ?$/

prompt pass
    match /[Pp]assword: $/

\# MACROS

macro paging
      send screen-length disable
      match generic

macro begin_privileged
    send enable
    match user or pass or privileged

macro end_privileged
    send disable
    match generic

macro begin_configure
    send configure terminal
    match configure

macro end_configure
    send exit
    match privileged

macro disconnect
    send quit
    match generic

\# macro completion
\#     send ?

\# for setting up automated reloading, requires argument N (minutes)
\# note: if done as send-match sequence, then the 'has been modified' part
\# is mandatory - but not all ios versions have that prompt...
\# the follow...with construction on the other hand works with or without
\# that step.
\# note all lines that are matched against prompt or follow are STRIPPED from the response.
macro reload_in
    send reload in %s
\#   match /System configuration has been modified. Save\? \[yes\/no\]:/
\#   send no
    follow /System configuration has been modified. Save\? \[yes\/no\]:/ with  no\n
    match /Proceed with reload\? \[confirm\]/
    send ''
    match privileged

\# no arguments. last match is pretty much a dud, the session will be gone.
macro reload
    send reload
    follow /System configuration has been modified. Save\? \[yes\/no\]:/ with  no\n
    match /Proceed with reload\? \[confirm\]/
    send ''
    match privileged